### PR TITLE
Feat: #5 - 공통 응답, 에러 핸들링 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.postgresql:postgresql'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/example/tripy/global/common/response/ApiResponse.java
+++ b/src/main/java/com/example/tripy/global/common/response/ApiResponse.java
@@ -1,0 +1,31 @@
+package com.example.tripy.global.common.response;
+
+import com.example.tripy.global.common.response.code.status.SuccessStatus;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@JsonPropertyOrder({"isSuccess", "code", "message", "result"})
+public class ApiResponse<T> {
+
+    @JsonProperty("isSuccess")
+    private final Boolean isSuccess;
+    private final String code;
+    private final String message;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private T result;
+
+    // 성공한 경우 응답 생성
+    public static <T> ApiResponse<T> onSuccess(T result){
+        return new ApiResponse<>(true, SuccessStatus._OK.getCode() , SuccessStatus._OK.getMessage(), result);
+    }
+
+    // 실패한 경우 응답 생성
+    public static <T> ApiResponse<T> onFailure(String code, String message, T data){
+        return new ApiResponse<>(false, code, message, data);
+    }
+}

--- a/src/main/java/com/example/tripy/global/common/response/code/BaseErrorCode.java
+++ b/src/main/java/com/example/tripy/global/common/response/code/BaseErrorCode.java
@@ -1,0 +1,5 @@
+package com.example.tripy.global.common.response.code;
+
+public interface BaseErrorCode {
+    public ErrorReasonDto getReasonHttpStatus();
+}

--- a/src/main/java/com/example/tripy/global/common/response/code/ErrorReasonDto.java
+++ b/src/main/java/com/example/tripy/global/common/response/code/ErrorReasonDto.java
@@ -1,0 +1,16 @@
+package com.example.tripy.global.common.response.code;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class ErrorReasonDto {
+
+    private HttpStatus httpStatus;
+
+    private final boolean isSuccess;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/tripy/global/common/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/tripy/global/common/response/code/status/ErrorStatus.java
@@ -1,0 +1,39 @@
+package com.example.tripy.global.common.response.code.status;
+
+import com.example.tripy.global.common.response.code.BaseErrorCode;
+import com.example.tripy.global.common.response.code.ErrorReasonDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorStatus implements BaseErrorCode {
+    //일반 응답
+    _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
+    _BAD_REQUEST(HttpStatus.BAD_REQUEST,"COMMON400","잘못된 요청입니다."),
+    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
+
+    //멤버 관련
+    _EMPTY_MEMBER(HttpStatus.CONFLICT, "MEMBER_001", "존재하지 않는 사용자입니다."),
+
+    //인증 관련
+    _EMPTY_JWT(HttpStatus.UNAUTHORIZED, "AUTH_001", "JWT가 존재하지 않습니다."),
+    _INVALID_JWT(HttpStatus.UNAUTHORIZED, "AUTH_002", "유효하지 않은 JWT입니다.")
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ErrorReasonDto getReasonHttpStatus() {
+        return ErrorReasonDto.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .build();
+    }
+}

--- a/src/main/java/com/example/tripy/global/common/response/code/status/SuccessStatus.java
+++ b/src/main/java/com/example/tripy/global/common/response/code/status/SuccessStatus.java
@@ -1,0 +1,18 @@
+package com.example.tripy.global.common.response.code.status;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessStatus  {
+
+    // 공통 응답
+    _OK(HttpStatus.OK, "COMMON200", "성공입니다."),
+    ;
+    
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/tripy/global/common/response/exception/ExceptionAdvice.java
+++ b/src/main/java/com/example/tripy/global/common/response/exception/ExceptionAdvice.java
@@ -26,7 +26,8 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 public class ExceptionAdvice extends ResponseEntityExceptionHandler {
 
 
-    @org.springframework.web.bind.annotation.ExceptionHandler
+    // Bean Validation에서 제약 조건 위반 시 발생하는 예외를 처리
+    @ExceptionHandler
     public ResponseEntity<Object> validation(ConstraintViolationException e, WebRequest request) {
         String errorMessage = e.getConstraintViolations().stream()
                 .map(constraintViolation -> constraintViolation.getMessage())
@@ -36,7 +37,7 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
         return handleExceptionInternalConstraint(e, ErrorStatus.valueOf(errorMessage), HttpHeaders.EMPTY,request);
     }
 
-
+    // @Valid 어노테이션을 통한 검증 실패 시 발생하는 예외를 처리
     @Override
     public ResponseEntity<Object> handleMethodArgumentNotValid(
             MethodArgumentNotValidException e, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
@@ -53,13 +54,15 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
         return handleExceptionInternalArgs(e,HttpHeaders.EMPTY,ErrorStatus.valueOf("_BAD_REQUEST"),request,errors);
     }
 
-    @org.springframework.web.bind.annotation.ExceptionHandler
+    // 모든 Exception 클래스 타입의 예외 처리
+    @ExceptionHandler
     public ResponseEntity<Object> exception(Exception e, WebRequest request) {
         e.printStackTrace();
 
         return handleExceptionInternalFalse(e, ErrorStatus._INTERNAL_SERVER_ERROR, HttpHeaders.EMPTY, ErrorStatus._INTERNAL_SERVER_ERROR.getHttpStatus(),request, e.getMessage());
     }
 
+    // 사용자 정의 예외 처리
     @ExceptionHandler(value = GeneralException.class)
     public ResponseEntity onThrowException(GeneralException generalException, HttpServletRequest request) {
         ErrorReasonDto errorReasonHttpStatus = generalException.getErrorReasonHttpStatus();
@@ -80,6 +83,7 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
         );
     }
 
+    // 공통 예외 처리 메소드
     private ResponseEntity<Object> handleExceptionInternalFalse(Exception e, ErrorStatus errorCommonStatus,
                                                                 HttpHeaders headers, HttpStatus status, WebRequest request, String errorPoint) {
         ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(),errorCommonStatus.getMessage(),errorPoint);
@@ -92,6 +96,7 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
         );
     }
 
+    // 서버 에러 처리 메소드
     private ResponseEntity<Object> handleExceptionInternalArgs(Exception e, HttpHeaders headers, ErrorStatus errorCommonStatus,
                                                                WebRequest request, Map<String, String> errorArgs) {
         ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(),errorCommonStatus.getMessage(),errorArgs);
@@ -104,6 +109,7 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
         );
     }
 
+    // 검증 실패에 대한 처리 메소드
     private ResponseEntity<Object> handleExceptionInternalConstraint(Exception e, ErrorStatus errorCommonStatus,
                                                                      HttpHeaders headers, WebRequest request) {
         ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(), errorCommonStatus.getMessage(), null);

--- a/src/main/java/com/example/tripy/global/common/response/exception/ExceptionAdvice.java
+++ b/src/main/java/com/example/tripy/global/common/response/exception/ExceptionAdvice.java
@@ -1,0 +1,118 @@
+package com.example.tripy.global.common.response.exception;
+
+import com.example.tripy.global.common.response.ApiResponse;
+import com.example.tripy.global.common.response.code.ErrorReasonDto;
+import com.example.tripy.global.common.response.code.status.ErrorStatus;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@Slf4j
+@RestControllerAdvice(annotations = {RestController.class})
+public class ExceptionAdvice extends ResponseEntityExceptionHandler {
+
+
+    @org.springframework.web.bind.annotation.ExceptionHandler
+    public ResponseEntity<Object> validation(ConstraintViolationException e, WebRequest request) {
+        String errorMessage = e.getConstraintViolations().stream()
+                .map(constraintViolation -> constraintViolation.getMessage())
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("ConstraintViolationException 추출 도중 에러 발생"));
+
+        return handleExceptionInternalConstraint(e, ErrorStatus.valueOf(errorMessage), HttpHeaders.EMPTY,request);
+    }
+
+
+    @Override
+    public ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException e, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+
+        Map<String, String> errors = new LinkedHashMap<>();
+
+        e.getBindingResult().getFieldErrors().stream()
+                .forEach(fieldError -> {
+                    String fieldName = fieldError.getField();
+                    String errorMessage = Optional.ofNullable(fieldError.getDefaultMessage()).orElse("");
+                    errors.merge(fieldName, errorMessage, (existingErrorMessage, newErrorMessage) -> existingErrorMessage + ", " + newErrorMessage);
+                });
+
+        return handleExceptionInternalArgs(e,HttpHeaders.EMPTY,ErrorStatus.valueOf("_BAD_REQUEST"),request,errors);
+    }
+
+    @org.springframework.web.bind.annotation.ExceptionHandler
+    public ResponseEntity<Object> exception(Exception e, WebRequest request) {
+        e.printStackTrace();
+
+        return handleExceptionInternalFalse(e, ErrorStatus._INTERNAL_SERVER_ERROR, HttpHeaders.EMPTY, ErrorStatus._INTERNAL_SERVER_ERROR.getHttpStatus(),request, e.getMessage());
+    }
+
+    @ExceptionHandler(value = GeneralException.class)
+    public ResponseEntity onThrowException(GeneralException generalException, HttpServletRequest request) {
+        ErrorReasonDto errorReasonHttpStatus = generalException.getErrorReasonHttpStatus();
+        return handleExceptionInternal(generalException,errorReasonHttpStatus,null,request);
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(Exception e, ErrorReasonDto reason,
+                                                           HttpHeaders headers, HttpServletRequest request) {
+
+        ApiResponse<Object> body = ApiResponse.onFailure(reason.getCode(),reason.getMessage(),null);
+        WebRequest webRequest = new ServletWebRequest(request);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                reason.getHttpStatus(),
+                webRequest
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalFalse(Exception e, ErrorStatus errorCommonStatus,
+                                                                HttpHeaders headers, HttpStatus status, WebRequest request, String errorPoint) {
+        ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(),errorCommonStatus.getMessage(),errorPoint);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                status,
+                request
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalArgs(Exception e, HttpHeaders headers, ErrorStatus errorCommonStatus,
+                                                               WebRequest request, Map<String, String> errorArgs) {
+        ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(),errorCommonStatus.getMessage(),errorArgs);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                errorCommonStatus.getHttpStatus(),
+                request
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalConstraint(Exception e, ErrorStatus errorCommonStatus,
+                                                                     HttpHeaders headers, WebRequest request) {
+        ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(), errorCommonStatus.getMessage(), null);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                errorCommonStatus.getHttpStatus(),
+                request
+        );
+    }
+}

--- a/src/main/java/com/example/tripy/global/common/response/exception/GeneralException.java
+++ b/src/main/java/com/example/tripy/global/common/response/exception/GeneralException.java
@@ -1,0 +1,17 @@
+package com.example.tripy.global.common.response.exception;
+
+import com.example.tripy.global.common.response.code.BaseErrorCode;
+import com.example.tripy.global.common.response.code.ErrorReasonDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GeneralException extends RuntimeException {
+
+    private BaseErrorCode code;
+
+    public ErrorReasonDto getErrorReasonHttpStatus() {
+        return this.code.getReasonHttpStatus();
+    }
+}


### PR DESCRIPTION
## 요약

- base response 생성
- 에러 핸들링 추가

## 상세 내용

- api 응답시 Json 구조를 통일시켰습니다.
- API 호출 성공한 경우
```json
{
    "isSuccess": true,
    "code": "COMMON200",
    "message": "성공입니다.",
    "result": {
        "title": "응답 테스트",
        "content" : "성공~!!"
    }
}

 ```

- API 호출 실패한 경우

```json
{
    "isSuccess": false,
    "code": "COMMON400",
    "message": "잘못된 요청입니다."
}
```

---

## 사용

### pathvariable로 정수를 받아 0이면 정상 출력 1이면 에러를 발생시키는 예제입니다.

- TempController

```java
@GetMapping("/exception/{id}")
    public ApiResponse<TempTestDto> testError(@PathVariable Long id) {
        return ApiResponse.onSuccess(tempService.errorTest(id));
    }
```

- TempService
```java
public TempTestDto errorTest(Long flag) {
        if(flag == 1) {
            throw new TempHandler(ErrorStatus._BAD_REQUEST);
        }
        return TempTestDto.builder()
                .testString("error test api")
                .build();
    }
```

- TempResponse

```java
@Builder
    @Getter
    @NoArgsConstructor
    @AllArgsConstructor
    public static class TempTestDto {
        String testString;
    }
```

- TempHandler

```java
public TempHandler(BaseErrorCode errorCode) {
        super(errorCode);
    }
```


## 질문 및 이외 사항

- 스프링 8주차 워크북을 참고했습니다.
- 자세한 동작 원리는 워크북을 참고하면 좋을 것 같습니다.
- 혹시 작성한 예시 코드에서 이해가 잘 되지 않는 부분이 있으시다면 코멘트 남겨주세요!!
++ isSuccess가 있으면 프론트측에서 편하다고 `리버`가 말해주어 추가하였습니다.  

## 이슈 번호

-  close #5 
