### PR TITLE
Feat: Bag

### DIFF
--- a/src/main/java/com/example/tripy/domain/bag/Bag.java
+++ b/src/main/java/com/example/tripy/domain/bag/Bag.java
@@ -1,12 +1,9 @@
-package com.example.tripy.domain.post;
+package com.example.tripy.domain.bag;
 
-import com.example.tripy.domain.city.City;
-import com.example.tripy.domain.postfile.PostFile;
-import com.example.tripy.domain.posttag.PostTag;
+import com.example.tripy.domain.bagmaterials.BagMaterials;
 import com.example.tripy.domain.travelplan.TravelPlan;
 import com.example.tripy.domain.user.User;
 import com.example.tripy.global.utils.BaseTimeEntity;
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -26,44 +23,31 @@ import org.hibernate.annotations.ColumnDefault;
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity
-public class Post extends BaseTimeEntity {
+public class Bag extends BaseTimeEntity {
 
-    // TODO: 2023/12/18 user,city, plan 연관관계 매핑
+
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @NotNull
-    private String title;
+    private String bagName;
 
     @NotNull
     private String content;
 
-    @ColumnDefault("0")
-    private Long view;
-
-    @ColumnDefault("0")
-    private Integer thumbs;
-
-    private Integer category;
 
     @ManyToOne
     @JoinColumn(name = "user_id")
     private User user;
 
     @ManyToOne
-    @JoinColumn(name = "city_id")
-    private City city;
-
-    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
-    private List<PostFile> postFiles = new ArrayList<>();
-
-    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
-    private List<PostTag> postTags = new ArrayList<>();
-
-    @ManyToOne
     @JoinColumn(name = "travelplan_id")
     private TravelPlan travelPlan;
+
+    @OneToMany(mappedBy = "bag")
+    private List<BagMaterials> bagMaterials = new ArrayList<>();
+
 
 }

--- a/src/main/java/com/example/tripy/domain/bag/Bag.java
+++ b/src/main/java/com/example/tripy/domain/bag/Bag.java
@@ -5,6 +5,7 @@ import com.example.tripy.domain.travelplan.TravelPlan;
 import com.example.tripy.domain.user.User;
 import com.example.tripy.global.utils.BaseTimeEntity;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -38,15 +39,15 @@ public class Bag extends BaseTimeEntity {
     private String content;
 
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "travelplan_id")
     private TravelPlan travelPlan;
 
-    @OneToMany(mappedBy = "bag")
+    @OneToMany(mappedBy = "bag", fetch = FetchType.LAZY)
     private List<BagMaterials> bagMaterials = new ArrayList<>();
 
 

--- a/src/main/java/com/example/tripy/domain/bag/BagController.java
+++ b/src/main/java/com/example/tripy/domain/bag/BagController.java
@@ -1,9 +1,8 @@
-package com.example.tripy.domain.posttag;
+package com.example.tripy.domain.bag;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RestController;
-
 @RequiredArgsConstructor
 @RestController
-public class PostTagController {
+public class BagController {
 }

--- a/src/main/java/com/example/tripy/domain/bag/BagRepository.java
+++ b/src/main/java/com/example/tripy/domain/bag/BagRepository.java
@@ -1,0 +1,6 @@
+package com.example.tripy.domain.bag;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BagRepository extends JpaRepository<Bag, Long> {
+}

--- a/src/main/java/com/example/tripy/domain/bag/BagService.java
+++ b/src/main/java/com/example/tripy/domain/bag/BagService.java
@@ -1,0 +1,9 @@
+package com.example.tripy.domain.bag;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class BagService {
+}

--- a/src/main/java/com/example/tripy/domain/bagmaterials/BagMaterials.java
+++ b/src/main/java/com/example/tripy/domain/bagmaterials/BagMaterials.java
@@ -5,6 +5,7 @@ import com.example.tripy.domain.material.Material;
 import com.example.tripy.global.utils.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -29,11 +30,11 @@ public class BagMaterials extends BaseTimeEntity {
     @Column(columnDefinition = "boolean default false")
     private boolean check;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "bag_id")
     private Bag bag;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "materials_id")
     private Material material;
 }

--- a/src/main/java/com/example/tripy/domain/bagmaterials/BagMaterials.java
+++ b/src/main/java/com/example/tripy/domain/bagmaterials/BagMaterials.java
@@ -1,8 +1,9 @@
-package com.example.tripy.domain.posttag;
+package com.example.tripy.domain.bagmaterials;
 
-import com.example.tripy.domain.post.Post;
-import com.example.tripy.domain.tag.Tag;
+import com.example.tripy.domain.bag.Bag;
+import com.example.tripy.domain.material.Material;
 import com.example.tripy.global.utils.BaseTimeEntity;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -18,22 +19,21 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity
-public class PostTag extends BaseTimeEntity {
+public class BagMaterials extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
-    @JoinColumn(name = "post_id")
-    private Post post;
+    @NotNull
+    @Column(columnDefinition = "boolean default false")
+    private boolean check;
 
     @ManyToOne
-    @JoinColumn(name = "tag_id")
-    private Tag tag;
-    
+    @JoinColumn(name = "bag_id")
+    private Bag bag;
 
+    @ManyToOne
+    @JoinColumn(name = "materials_id")
+    private Material material;
 }
-
-
-

--- a/src/main/java/com/example/tripy/domain/bagmaterials/BagMaterialsController.java
+++ b/src/main/java/com/example/tripy/domain/bagmaterials/BagMaterialsController.java
@@ -1,9 +1,8 @@
-package com.example.tripy.domain.posttag;
+package com.example.tripy.domain.bagmaterials;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RestController;
-
 @RequiredArgsConstructor
 @RestController
-public class PostTagController {
+public class BagMaterialsController {
 }

--- a/src/main/java/com/example/tripy/domain/bagmaterials/BagMaterialsRepository.java
+++ b/src/main/java/com/example/tripy/domain/bagmaterials/BagMaterialsRepository.java
@@ -1,0 +1,6 @@
+package com.example.tripy.domain.bagmaterials;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BagMaterialsRepository extends JpaRepository<BagMaterials, Long> {
+}

--- a/src/main/java/com/example/tripy/domain/bagmaterials/BagMaterialsService.java
+++ b/src/main/java/com/example/tripy/domain/bagmaterials/BagMaterialsService.java
@@ -1,0 +1,9 @@
+package com.example.tripy.domain.bagmaterials;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class BagMaterialsService {
+}

--- a/src/main/java/com/example/tripy/domain/city/City.java
+++ b/src/main/java/com/example/tripy/domain/city/City.java
@@ -1,0 +1,55 @@
+package com.example.tripy.domain.city;
+
+import com.example.tripy.domain.cityplan.CityPlan;
+import com.example.tripy.domain.country.Country;
+import com.example.tripy.domain.landmark.Landmark;
+import com.example.tripy.domain.post.Post;
+import com.example.tripy.global.utils.BaseTimeEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+public class City extends BaseTimeEntity{
+
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    private String name;
+
+    @NotNull
+    private Double latitude;
+
+    @NotNull
+    private Double longitude;
+
+    @OneToMany(mappedBy = "city")
+    private List<CityPlan> cityplans = new ArrayList<>();
+
+    @OneToOne
+    @JoinColumn(name = "country_id")
+    private Country country;
+
+    @OneToMany(mappedBy = "city")
+    private List<Landmark> landmarks = new ArrayList<>();
+
+    @OneToMany(mappedBy = "city")
+    private List<Post> posts = new ArrayList<>();
+
+}

--- a/src/main/java/com/example/tripy/domain/city/City.java
+++ b/src/main/java/com/example/tripy/domain/city/City.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.validation.constraints.NotNull;
@@ -42,7 +43,7 @@ public class City extends BaseTimeEntity{
     @OneToMany(mappedBy = "city")
     private List<CityPlan> cityplans = new ArrayList<>();
 
-    @OneToOne
+    @ManyToOne
     @JoinColumn(name = "country_id")
     private Country country;
 

--- a/src/main/java/com/example/tripy/domain/city/City.java
+++ b/src/main/java/com/example/tripy/domain/city/City.java
@@ -6,6 +6,7 @@ import com.example.tripy.domain.landmark.Landmark;
 import com.example.tripy.domain.post.Post;
 import com.example.tripy.global.utils.BaseTimeEntity;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -40,17 +41,17 @@ public class City extends BaseTimeEntity{
     @NotNull
     private Double longitude;
 
-    @OneToMany(mappedBy = "city")
+    @OneToMany(mappedBy = "city", fetch = FetchType.LAZY)
     private List<CityPlan> cityplans = new ArrayList<>();
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "country_id")
     private Country country;
 
-    @OneToMany(mappedBy = "city")
+    @OneToMany(mappedBy = "city", fetch = FetchType.LAZY)
     private List<Landmark> landmarks = new ArrayList<>();
 
-    @OneToMany(mappedBy = "city")
+    @OneToMany(mappedBy = "city", fetch = FetchType.LAZY)
     private List<Post> posts = new ArrayList<>();
 
 }

--- a/src/main/java/com/example/tripy/domain/city/CityController.java
+++ b/src/main/java/com/example/tripy/domain/city/CityController.java
@@ -1,9 +1,8 @@
-package com.example.tripy.domain.posttag;
+package com.example.tripy.domain.city;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RestController;
-
 @RequiredArgsConstructor
 @RestController
-public class PostTagController {
+public class CityController {
 }

--- a/src/main/java/com/example/tripy/domain/city/CityRepository.java
+++ b/src/main/java/com/example/tripy/domain/city/CityRepository.java
@@ -1,0 +1,6 @@
+package com.example.tripy.domain.city;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CityRepository extends JpaRepository<City, Long> {
+}

--- a/src/main/java/com/example/tripy/domain/city/CityService.java
+++ b/src/main/java/com/example/tripy/domain/city/CityService.java
@@ -1,0 +1,9 @@
+package com.example.tripy.domain.city;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class CityService {
+}

--- a/src/main/java/com/example/tripy/domain/cityplan/CityPlan.java
+++ b/src/main/java/com/example/tripy/domain/cityplan/CityPlan.java
@@ -4,6 +4,7 @@ import com.example.tripy.domain.city.City;
 import com.example.tripy.domain.travelplan.TravelPlan;
 import com.example.tripy.global.utils.BaseTimeEntity;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -27,11 +28,11 @@ public class CityPlan extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "city_id")
     private City city;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "travelplan_id")
     private TravelPlan travelPlan;
 }

--- a/src/main/java/com/example/tripy/domain/cityplan/CityPlan.java
+++ b/src/main/java/com/example/tripy/domain/cityplan/CityPlan.java
@@ -1,11 +1,14 @@
-package com.example.tripy.domain.tag;
+package com.example.tripy.domain.cityplan;
 
-import com.example.tripy.domain.posttag.PostTag;
+import com.example.tripy.domain.city.City;
+import com.example.tripy.domain.travelplan.TravelPlan;
 import com.example.tripy.global.utils.BaseTimeEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.validation.constraints.NotNull;
 import java.util.ArrayList;
@@ -18,16 +21,17 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity
-public class Tag extends BaseTimeEntity {
+public class CityPlan extends BaseTimeEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @NotNull
-    private String tagName;
+    @ManyToOne
+    @JoinColumn(name = "city_id")
+    private City city ;
 
-    @OneToMany(mappedBy = "tag")
-    private List<PostTag> postTags = new ArrayList<>();
-
-
+    @ManyToOne
+    @JoinColumn(name = "travelplan_id")
+    private TravelPlan travelPlan;
 }

--- a/src/main/java/com/example/tripy/domain/cityplan/CityPlan.java
+++ b/src/main/java/com/example/tripy/domain/cityplan/CityPlan.java
@@ -29,7 +29,7 @@ public class CityPlan extends BaseTimeEntity {
 
     @ManyToOne
     @JoinColumn(name = "city_id")
-    private City city ;
+    private City city;
 
     @ManyToOne
     @JoinColumn(name = "travelplan_id")

--- a/src/main/java/com/example/tripy/domain/cityplan/CityPlanController.java
+++ b/src/main/java/com/example/tripy/domain/cityplan/CityPlanController.java
@@ -1,9 +1,8 @@
-package com.example.tripy.domain.posttag;
+package com.example.tripy.domain.cityplan;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RestController;
-
 @RequiredArgsConstructor
 @RestController
-public class PostTagController {
+public class CityPlanController {
 }

--- a/src/main/java/com/example/tripy/domain/cityplan/CityPlanRepository.java
+++ b/src/main/java/com/example/tripy/domain/cityplan/CityPlanRepository.java
@@ -1,0 +1,6 @@
+package com.example.tripy.domain.cityplan;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CityPlanRepository extends JpaRepository<CityPlan, Long> {
+}

--- a/src/main/java/com/example/tripy/domain/cityplan/CityPlanService.java
+++ b/src/main/java/com/example/tripy/domain/cityplan/CityPlanService.java
@@ -1,9 +1,9 @@
-package com.example.tripy.domain.postimage;
+package com.example.tripy.domain.cityplan;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
 @Service
-public class PostImageService {
+public class CityPlanService {
 }

--- a/src/main/java/com/example/tripy/domain/continent/Continent.java
+++ b/src/main/java/com/example/tripy/domain/continent/Continent.java
@@ -1,15 +1,10 @@
-package com.example.tripy.domain.tag;
+package com.example.tripy.domain.continent;
 
-import com.example.tripy.domain.posttag.PostTag;
-import com.example.tripy.global.utils.BaseTimeEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
 import jakarta.validation.constraints.NotNull;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -18,16 +13,15 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity
-public class Tag extends BaseTimeEntity {
+public class Continent {
+
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @NotNull
-    private String tagName;
-
-    @OneToMany(mappedBy = "tag")
-    private List<PostTag> postTags = new ArrayList<>();
-
+    private String name;
+    
 
 }

--- a/src/main/java/com/example/tripy/domain/continent/Continent.java
+++ b/src/main/java/com/example/tripy/domain/continent/Continent.java
@@ -2,6 +2,7 @@ package com.example.tripy.domain.continent;
 
 import com.example.tripy.domain.country.Country;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -27,7 +28,7 @@ public class Continent {
     @NotNull
     private String name;
 
-    @OneToMany(mappedBy = "continent")
+    @OneToMany(mappedBy = "continent", fetch = FetchType.LAZY)
     private List<Country> countries = new ArrayList<>();
     
 

--- a/src/main/java/com/example/tripy/domain/continent/Continent.java
+++ b/src/main/java/com/example/tripy/domain/continent/Continent.java
@@ -1,10 +1,14 @@
 package com.example.tripy.domain.continent;
 
+import com.example.tripy.domain.country.Country;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -22,6 +26,9 @@ public class Continent {
 
     @NotNull
     private String name;
+
+    @OneToMany(mappedBy = "continent")
+    private List<Country> countries = new ArrayList<>();
     
 
 }

--- a/src/main/java/com/example/tripy/domain/continent/ContinentController.java
+++ b/src/main/java/com/example/tripy/domain/continent/ContinentController.java
@@ -1,9 +1,8 @@
-package com.example.tripy.domain.posttag;
+package com.example.tripy.domain.continent;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RestController;
-
 @RequiredArgsConstructor
 @RestController
-public class PostTagController {
+public class ContinentController {
 }

--- a/src/main/java/com/example/tripy/domain/continent/ContinentRepository.java
+++ b/src/main/java/com/example/tripy/domain/continent/ContinentRepository.java
@@ -1,0 +1,6 @@
+package com.example.tripy.domain.continent;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ContinentRepository extends JpaRepository<Continent, Long> {
+}

--- a/src/main/java/com/example/tripy/domain/continent/ContinentService.java
+++ b/src/main/java/com/example/tripy/domain/continent/ContinentService.java
@@ -1,0 +1,9 @@
+package com.example.tripy.domain.continent;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class ContinentService {
+}

--- a/src/main/java/com/example/tripy/domain/conversation/Conversation.java
+++ b/src/main/java/com/example/tripy/domain/conversation/Conversation.java
@@ -1,15 +1,14 @@
-package com.example.tripy.domain.tag;
+package com.example.tripy.domain.conversation;
 
-import com.example.tripy.domain.posttag.PostTag;
-import com.example.tripy.global.utils.BaseTimeEntity;
+import com.example.tripy.domain.country.Country;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.validation.constraints.NotNull;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -18,16 +17,23 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity
-public class Tag extends BaseTimeEntity {
+public class Conversation {
+
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @NotNull
-    private String tagName;
+    private String korean;
 
-    @OneToMany(mappedBy = "tag")
-    private List<PostTag> postTags = new ArrayList<>();
+    private String translation;
 
+    @ManyToOne
+    @JoinColumn(name = "country_id")
+    private Country country;
+
+
+    
 
 }

--- a/src/main/java/com/example/tripy/domain/conversation/Conversation.java
+++ b/src/main/java/com/example/tripy/domain/conversation/Conversation.java
@@ -2,6 +2,7 @@ package com.example.tripy.domain.conversation;
 
 import com.example.tripy.domain.country.Country;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -29,7 +30,7 @@ public class Conversation {
 
     private String translation;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "country_id")
     private Country country;
 

--- a/src/main/java/com/example/tripy/domain/conversation/ConversationController.java
+++ b/src/main/java/com/example/tripy/domain/conversation/ConversationController.java
@@ -1,9 +1,8 @@
-package com.example.tripy.domain.posttag;
+package com.example.tripy.domain.conversation;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RestController;
-
 @RequiredArgsConstructor
 @RestController
-public class PostTagController {
+public class ConversationController {
 }

--- a/src/main/java/com/example/tripy/domain/conversation/ConversationRepository.java
+++ b/src/main/java/com/example/tripy/domain/conversation/ConversationRepository.java
@@ -1,0 +1,6 @@
+package com.example.tripy.domain.conversation;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ConversationRepository extends JpaRepository<Conversation, Long> {
+}

--- a/src/main/java/com/example/tripy/domain/conversation/ConversationService.java
+++ b/src/main/java/com/example/tripy/domain/conversation/ConversationService.java
@@ -1,0 +1,9 @@
+package com.example.tripy.domain.conversation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class ConversationService {
+}

--- a/src/main/java/com/example/tripy/domain/country/Country.java
+++ b/src/main/java/com/example/tripy/domain/country/Country.java
@@ -11,6 +11,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.validation.constraints.NotNull;
@@ -34,14 +35,14 @@ public class Country {
     @NotNull
     private String name;
 
-    @OneToOne(mappedBy = "country")
-    private City city;
+    @OneToMany(mappedBy = "country")
+    private List<City> cities = new ArrayList<>();
 
     @OneToOne
     @JoinColumn(name = "currency_id")
     private Currency currency;
 
-    @OneToOne
+    @ManyToOne
     @JoinColumn(name = "continent_id")
     private Continent continent;
 

--- a/src/main/java/com/example/tripy/domain/country/Country.java
+++ b/src/main/java/com/example/tripy/domain/country/Country.java
@@ -1,0 +1,55 @@
+package com.example.tripy.domain.country;
+
+import com.example.tripy.domain.city.City;
+import com.example.tripy.domain.continent.Continent;
+import com.example.tripy.domain.conversation.Conversation;
+import com.example.tripy.domain.countrymaterial.CountryMaterial;
+import com.example.tripy.domain.currency.Currency;
+import com.example.tripy.global.utils.BaseTimeEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+public class Country {
+
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    private String name;
+
+    @OneToOne(mappedBy = "country")
+    private City city;
+
+    @OneToOne
+    @JoinColumn(name = "currency_id")
+    private Currency currency;
+
+    @OneToOne
+    @JoinColumn(name = "continent_id")
+    private Continent continent;
+
+    @OneToMany(mappedBy = "country")
+    private List<Conversation> conversations = new ArrayList<>();
+
+    @OneToMany(mappedBy = "country")
+    private List<CountryMaterial> countryMaterials = new ArrayList<>();
+    
+
+}

--- a/src/main/java/com/example/tripy/domain/country/Country.java
+++ b/src/main/java/com/example/tripy/domain/country/Country.java
@@ -7,6 +7,7 @@ import com.example.tripy.domain.countrymaterial.CountryMaterial;
 import com.example.tripy.domain.currency.Currency;
 import com.example.tripy.global.utils.BaseTimeEntity;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -35,21 +36,21 @@ public class Country {
     @NotNull
     private String name;
 
-    @OneToMany(mappedBy = "country")
+    @OneToMany(mappedBy = "country", fetch = FetchType.LAZY)
     private List<City> cities = new ArrayList<>();
 
     @OneToOne
     @JoinColumn(name = "currency_id")
     private Currency currency;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "continent_id")
     private Continent continent;
 
-    @OneToMany(mappedBy = "country")
+    @OneToMany(mappedBy = "country", fetch = FetchType.LAZY)
     private List<Conversation> conversations = new ArrayList<>();
 
-    @OneToMany(mappedBy = "country")
+    @OneToMany(mappedBy = "country", fetch = FetchType.LAZY)
     private List<CountryMaterial> countryMaterials = new ArrayList<>();
     
 

--- a/src/main/java/com/example/tripy/domain/country/CountryController.java
+++ b/src/main/java/com/example/tripy/domain/country/CountryController.java
@@ -1,9 +1,8 @@
-package com.example.tripy.domain.posttag;
+package com.example.tripy.domain.country;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RestController;
-
 @RequiredArgsConstructor
 @RestController
-public class PostTagController {
+public class CountryController {
 }

--- a/src/main/java/com/example/tripy/domain/country/CountryRepository.java
+++ b/src/main/java/com/example/tripy/domain/country/CountryRepository.java
@@ -1,0 +1,6 @@
+package com.example.tripy.domain.country;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CountryRepository extends JpaRepository<Country, Long> {
+}

--- a/src/main/java/com/example/tripy/domain/country/CountryService.java
+++ b/src/main/java/com/example/tripy/domain/country/CountryService.java
@@ -1,0 +1,9 @@
+package com.example.tripy.domain.country;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class CountryService {
+}

--- a/src/main/java/com/example/tripy/domain/countrymaterial/CountryMaterial.java
+++ b/src/main/java/com/example/tripy/domain/countrymaterial/CountryMaterial.java
@@ -3,6 +3,7 @@ package com.example.tripy.domain.countrymaterial;
 import com.example.tripy.domain.country.Country;
 import com.example.tripy.domain.material.Material;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -25,11 +26,11 @@ public class CountryMaterial {
 
     private String description;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "country_id")
     private Country country;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "materials_id")
     private Material material;
 

--- a/src/main/java/com/example/tripy/domain/countrymaterial/CountryMaterial.java
+++ b/src/main/java/com/example/tripy/domain/countrymaterial/CountryMaterial.java
@@ -1,15 +1,13 @@
-package com.example.tripy.domain.posttag;
+package com.example.tripy.domain.countrymaterial;
 
-import com.example.tripy.domain.post.Post;
-import com.example.tripy.domain.tag.Tag;
-import com.example.tripy.global.utils.BaseTimeEntity;
+import com.example.tripy.domain.country.Country;
+import com.example.tripy.domain.material.Material;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -18,22 +16,24 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity
-public class PostTag extends BaseTimeEntity {
+public class CountryMaterial {
+
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
-    @JoinColumn(name = "post_id")
-    private Post post;
+    private String description;
 
     @ManyToOne
-    @JoinColumn(name = "tag_id")
-    private Tag tag;
-    
+    @JoinColumn(name = "country_id")
+    private Country country;
+
+    @ManyToOne
+    @JoinColumn(name = "materials_id")
+    private Material material;
+
+
+
 
 }
-
-
-

--- a/src/main/java/com/example/tripy/domain/countrymaterial/CountryMaterialController.java
+++ b/src/main/java/com/example/tripy/domain/countrymaterial/CountryMaterialController.java
@@ -1,9 +1,8 @@
-package com.example.tripy.domain.posttag;
+package com.example.tripy.domain.countrymaterial;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RestController;
-
 @RequiredArgsConstructor
 @RestController
-public class PostTagController {
+public class CountryMaterialController {
 }

--- a/src/main/java/com/example/tripy/domain/countrymaterial/CountryMaterialRepository.java
+++ b/src/main/java/com/example/tripy/domain/countrymaterial/CountryMaterialRepository.java
@@ -1,0 +1,6 @@
+package com.example.tripy.domain.countrymaterial;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CountryMaterialRepository extends JpaRepository<CountryMaterial, Long> {
+}

--- a/src/main/java/com/example/tripy/domain/countrymaterial/CountryMaterialService.java
+++ b/src/main/java/com/example/tripy/domain/countrymaterial/CountryMaterialService.java
@@ -1,0 +1,9 @@
+package com.example.tripy.domain.countrymaterial;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class CountryMaterialService {
+}

--- a/src/main/java/com/example/tripy/domain/currency/Currency.java
+++ b/src/main/java/com/example/tripy/domain/currency/Currency.java
@@ -1,15 +1,15 @@
-package com.example.tripy.domain.tag;
+package com.example.tripy.domain.currency;
 
-import com.example.tripy.domain.posttag.PostTag;
+import com.example.tripy.domain.continent.Continent;
+import com.example.tripy.domain.country.Country;
 import com.example.tripy.global.utils.BaseTimeEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
 import jakarta.validation.constraints.NotNull;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -18,16 +18,21 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity
-public class Tag extends BaseTimeEntity {
+public class Currency extends BaseTimeEntity {
+
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @NotNull
-    private String tagName;
+    private Long country_id;
 
-    @OneToMany(mappedBy = "tag")
-    private List<PostTag> postTags = new ArrayList<>();
+    private String currency_ko;
+
+    private String currency_en;
+
+    @OneToOne(mappedBy = "currency")
+    private Country country;
 
 
 }

--- a/src/main/java/com/example/tripy/domain/currency/Currency.java
+++ b/src/main/java/com/example/tripy/domain/currency/Currency.java
@@ -25,11 +25,11 @@ public class Currency extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private Long country_id;
+    private Long countryId;
 
-    private String currency_ko;
+    private String currencyKo;
 
-    private String currency_en;
+    private String currencyEn;
 
     @OneToOne(mappedBy = "currency")
     private Country country;

--- a/src/main/java/com/example/tripy/domain/currency/CurrencyController.java
+++ b/src/main/java/com/example/tripy/domain/currency/CurrencyController.java
@@ -1,9 +1,8 @@
-package com.example.tripy.domain.posttag;
+package com.example.tripy.domain.currency;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RestController;
-
 @RequiredArgsConstructor
 @RestController
-public class PostTagController {
+public class CurrencyController {
 }

--- a/src/main/java/com/example/tripy/domain/currency/CurrencyRepository.java
+++ b/src/main/java/com/example/tripy/domain/currency/CurrencyRepository.java
@@ -1,0 +1,6 @@
+package com.example.tripy.domain.currency;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CurrencyRepository extends JpaRepository<Currency, Long> {
+}

--- a/src/main/java/com/example/tripy/domain/currency/CurrencyService.java
+++ b/src/main/java/com/example/tripy/domain/currency/CurrencyService.java
@@ -1,0 +1,9 @@
+package com.example.tripy.domain.currency;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class CurrencyService {
+}

--- a/src/main/java/com/example/tripy/domain/friend/Friend.java
+++ b/src/main/java/com/example/tripy/domain/friend/Friend.java
@@ -1,15 +1,14 @@
-package com.example.tripy.domain.posttag;
+package com.example.tripy.domain.friend;
 
-import com.example.tripy.domain.post.Post;
-import com.example.tripy.domain.tag.Tag;
+import com.example.tripy.domain.user.User;
 import com.example.tripy.global.utils.BaseTimeEntity;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -18,22 +17,24 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity
-public class PostTag extends BaseTimeEntity {
+public class Friend extends BaseTimeEntity {
+
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
-    @JoinColumn(name = "post_id")
-    private Post post;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "from_user_id")
+    private User fromUser;
 
-    @ManyToOne
-    @JoinColumn(name = "tag_id")
-    private Tag tag;
-    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "to_user_id")
+    private User toUser;
+
+    private Boolean isFriend;
+
+    private Boolean isBlocked;
+
 
 }
-
-
-

--- a/src/main/java/com/example/tripy/domain/friend/FriendController.java
+++ b/src/main/java/com/example/tripy/domain/friend/FriendController.java
@@ -1,9 +1,8 @@
-package com.example.tripy.domain.posttag;
+package com.example.tripy.domain.friend;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RestController;
-
 @RequiredArgsConstructor
 @RestController
-public class PostTagController {
+public class FriendController {
 }

--- a/src/main/java/com/example/tripy/domain/friend/FriendRepository.java
+++ b/src/main/java/com/example/tripy/domain/friend/FriendRepository.java
@@ -1,0 +1,6 @@
+package com.example.tripy.domain.friend;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FriendRepository extends JpaRepository<Friend, Long> {
+}

--- a/src/main/java/com/example/tripy/domain/friend/FriendService.java
+++ b/src/main/java/com/example/tripy/domain/friend/FriendService.java
@@ -1,0 +1,9 @@
+package com.example.tripy.domain.friend;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class FriendService {
+}

--- a/src/main/java/com/example/tripy/domain/landmark/Landmark.java
+++ b/src/main/java/com/example/tripy/domain/landmark/Landmark.java
@@ -1,15 +1,13 @@
-package com.example.tripy.domain.tag;
+package com.example.tripy.domain.landmark;
 
-import com.example.tripy.domain.posttag.PostTag;
+import com.example.tripy.domain.city.City;
 import com.example.tripy.global.utils.BaseTimeEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
-import jakarta.validation.constraints.NotNull;
-import java.util.ArrayList;
-import java.util.List;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -18,16 +16,25 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity
-public class Tag extends BaseTimeEntity {
+public class Landmark extends BaseTimeEntity {
+
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @NotNull
-    private String tagName;
+    private String name;
 
-    @OneToMany(mappedBy = "tag")
-    private List<PostTag> postTags = new ArrayList<>();
+    private Boolean isPopular;
+
+    private Double latitude;
+
+    private Double longitude;
+
+    @ManyToOne
+    @JoinColumn(name = "city_id")
+    private City city;
+
 
 
 }

--- a/src/main/java/com/example/tripy/domain/landmark/Landmark.java
+++ b/src/main/java/com/example/tripy/domain/landmark/Landmark.java
@@ -3,6 +3,7 @@ package com.example.tripy.domain.landmark;
 import com.example.tripy.domain.city.City;
 import com.example.tripy.global.utils.BaseTimeEntity;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -31,7 +32,7 @@ public class Landmark extends BaseTimeEntity {
 
     private Double longitude;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "city_id")
     private City city;
 

--- a/src/main/java/com/example/tripy/domain/landmark/LandmarkController.java
+++ b/src/main/java/com/example/tripy/domain/landmark/LandmarkController.java
@@ -1,9 +1,8 @@
-package com.example.tripy.domain.posttag;
+package com.example.tripy.domain.landmark;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RestController;
-
 @RequiredArgsConstructor
 @RestController
-public class PostTagController {
+public class LandmarkController {
 }

--- a/src/main/java/com/example/tripy/domain/landmark/LandmarkRepository.java
+++ b/src/main/java/com/example/tripy/domain/landmark/LandmarkRepository.java
@@ -1,0 +1,6 @@
+package com.example.tripy.domain.landmark;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LandmarkRepository extends JpaRepository<Landmark, Long> {
+}

--- a/src/main/java/com/example/tripy/domain/landmark/LandmarkService.java
+++ b/src/main/java/com/example/tripy/domain/landmark/LandmarkService.java
@@ -1,0 +1,9 @@
+package com.example.tripy.domain.landmark;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class LandmarkService {
+}

--- a/src/main/java/com/example/tripy/domain/material/Material.java
+++ b/src/main/java/com/example/tripy/domain/material/Material.java
@@ -5,6 +5,7 @@ import com.example.tripy.domain.countrymaterial.CountryMaterial;
 import com.example.tripy.global.utils.BaseTimeEntity;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -28,10 +29,10 @@ public class Material extends BaseTimeEntity {
 
     private String name;
 
-    @OneToMany(mappedBy = "material", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "material", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<BagMaterials> bagMaterials = new ArrayList<>();
 
-    @OneToMany(mappedBy = "material", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "material", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<CountryMaterial> countryMaterials = new ArrayList<>();
 
 

--- a/src/main/java/com/example/tripy/domain/material/Material.java
+++ b/src/main/java/com/example/tripy/domain/material/Material.java
@@ -1,0 +1,39 @@
+package com.example.tripy.domain.material;
+
+import com.example.tripy.domain.bagmaterials.BagMaterials;
+import com.example.tripy.domain.countrymaterial.CountryMaterial;
+import com.example.tripy.global.utils.BaseTimeEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+public class Material extends BaseTimeEntity {
+
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    @OneToMany(mappedBy = "material", cascade = CascadeType.ALL)
+    private List<BagMaterials> bagMaterials = new ArrayList<>();
+
+    @OneToMany(mappedBy = "material", cascade = CascadeType.ALL)
+    private List<CountryMaterial> countryMaterials = new ArrayList<>();
+
+
+
+}

--- a/src/main/java/com/example/tripy/domain/material/MaterialController.java
+++ b/src/main/java/com/example/tripy/domain/material/MaterialController.java
@@ -1,9 +1,8 @@
-package com.example.tripy.domain.posttag;
+package com.example.tripy.domain.material;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RestController;
-
 @RequiredArgsConstructor
 @RestController
-public class PostTagController {
+public class MaterialController {
 }

--- a/src/main/java/com/example/tripy/domain/material/MaterialRepository.java
+++ b/src/main/java/com/example/tripy/domain/material/MaterialRepository.java
@@ -1,0 +1,6 @@
+package com.example.tripy.domain.material;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MaterialRepository extends JpaRepository<Material, Long> {
+}

--- a/src/main/java/com/example/tripy/domain/material/MaterialService.java
+++ b/src/main/java/com/example/tripy/domain/material/MaterialService.java
@@ -1,0 +1,9 @@
+package com.example.tripy.domain.material;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class MaterialService {
+}

--- a/src/main/java/com/example/tripy/domain/planfriend/PlanFriend.java
+++ b/src/main/java/com/example/tripy/domain/planfriend/PlanFriend.java
@@ -1,15 +1,15 @@
-package com.example.tripy.domain.posttag;
+package com.example.tripy.domain.planfriend;
 
-import com.example.tripy.domain.post.Post;
-import com.example.tripy.domain.tag.Tag;
+import com.example.tripy.domain.travelplan.TravelPlan;
+import com.example.tripy.domain.user.User;
 import com.example.tripy.global.utils.BaseTimeEntity;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -18,22 +18,19 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity
-public class PostTag extends BaseTimeEntity {
+public class PlanFriend extends BaseTimeEntity {
+
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne
-    @JoinColumn(name = "post_id")
-    private Post post;
+    @JoinColumn(name = "travelplan_id")
+    private TravelPlan travelPlan;
 
     @ManyToOne
-    @JoinColumn(name = "tag_id")
-    private Tag tag;
-    
+    @JoinColumn(name = "user_id")
+    private User user;
 
 }
-
-
-

--- a/src/main/java/com/example/tripy/domain/planfriend/PlanFriend.java
+++ b/src/main/java/com/example/tripy/domain/planfriend/PlanFriend.java
@@ -25,11 +25,11 @@ public class PlanFriend extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "travelplan_id")
     private TravelPlan travelPlan;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 

--- a/src/main/java/com/example/tripy/domain/planfriend/PlanFriendController.java
+++ b/src/main/java/com/example/tripy/domain/planfriend/PlanFriendController.java
@@ -1,9 +1,8 @@
-package com.example.tripy.domain.posttag;
+package com.example.tripy.domain.planfriend;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RestController;
-
 @RequiredArgsConstructor
 @RestController
-public class PostTagController {
+public class PlanFriendController {
 }

--- a/src/main/java/com/example/tripy/domain/planfriend/PlanFriendRepository.java
+++ b/src/main/java/com/example/tripy/domain/planfriend/PlanFriendRepository.java
@@ -1,0 +1,6 @@
+package com.example.tripy.domain.planfriend;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlanFriendRepository extends JpaRepository<PlanFriend, Long> {
+}

--- a/src/main/java/com/example/tripy/domain/planfriend/PlanFriendService.java
+++ b/src/main/java/com/example/tripy/domain/planfriend/PlanFriendService.java
@@ -1,0 +1,9 @@
+package com.example.tripy.domain.planfriend;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class PlanFriendService {
+}

--- a/src/main/java/com/example/tripy/domain/post/Post.java
+++ b/src/main/java/com/example/tripy/domain/post/Post.java
@@ -8,6 +8,7 @@ import com.example.tripy.domain.user.User;
 import com.example.tripy.global.utils.BaseTimeEntity;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -48,21 +49,21 @@ public class Post extends BaseTimeEntity {
 
     private Integer category;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "city_id")
     private City city;
 
-    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<PostFile> postFiles = new ArrayList<>();
 
-    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<PostTag> postTags = new ArrayList<>();
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "travelplan_id")
     private TravelPlan travelPlan;
 

--- a/src/main/java/com/example/tripy/domain/postfile/FileType.java
+++ b/src/main/java/com/example/tripy/domain/postfile/FileType.java
@@ -1,0 +1,5 @@
+package com.example.tripy.domain.postfile;
+
+public enum FileType {
+  파일, 링크, 사진
+}

--- a/src/main/java/com/example/tripy/domain/postfile/PostFile.java
+++ b/src/main/java/com/example/tripy/domain/postfile/PostFile.java
@@ -25,7 +25,7 @@ public class PostFile extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private FileType type;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")
     private Post post;
 

--- a/src/main/java/com/example/tripy/domain/postfile/PostFile.java
+++ b/src/main/java/com/example/tripy/domain/postfile/PostFile.java
@@ -1,4 +1,4 @@
-package com.example.tripy.domain.postimage;
+package com.example.tripy.domain.postfile;
 
 import com.example.tripy.domain.post.Post;
 import com.example.tripy.global.utils.BaseTimeEntity;
@@ -12,18 +12,24 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity
-public class PostImage extends BaseTimeEntity {
+public class PostFile extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @NotNull
-    private String imageUrl;
+    private String url;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private FileType type;
 
     @ManyToOne
     @JoinColumn(name = "post_id")
     private Post post;
+
+
 
 }
 

--- a/src/main/java/com/example/tripy/domain/postfile/PostFileController.java
+++ b/src/main/java/com/example/tripy/domain/postfile/PostFileController.java
@@ -1,9 +1,9 @@
-package com.example.tripy.domain.postimage;
+package com.example.tripy.domain.postfile;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RestController
-public class PostImageController {
+public class PostFileController {
 }

--- a/src/main/java/com/example/tripy/domain/postfile/PostFileRepository.java
+++ b/src/main/java/com/example/tripy/domain/postfile/PostFileRepository.java
@@ -1,0 +1,6 @@
+package com.example.tripy.domain.postfile;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostFileRepository extends JpaRepository<PostFile, Long> {
+}

--- a/src/main/java/com/example/tripy/domain/postfile/PostFileService.java
+++ b/src/main/java/com/example/tripy/domain/postfile/PostFileService.java
@@ -1,0 +1,9 @@
+package com.example.tripy.domain.postfile;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class PostFileService {
+}

--- a/src/main/java/com/example/tripy/domain/postimage/PostImageRepository.java
+++ b/src/main/java/com/example/tripy/domain/postimage/PostImageRepository.java
@@ -1,6 +1,0 @@
-package com.example.tripy.domain.postimage;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface PostImageRepository extends JpaRepository<PostImage, Long> {
-}

--- a/src/main/java/com/example/tripy/domain/posttag/PostTag.java
+++ b/src/main/java/com/example/tripy/domain/posttag/PostTag.java
@@ -4,6 +4,7 @@ import com.example.tripy.domain.post.Post;
 import com.example.tripy.domain.tag.Tag;
 import com.example.tripy.global.utils.BaseTimeEntity;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -24,11 +25,11 @@ public class PostTag extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")
     private Post post;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "tag_id")
     private Tag tag;
     

--- a/src/main/java/com/example/tripy/domain/tag/Tag.java
+++ b/src/main/java/com/example/tripy/domain/tag/Tag.java
@@ -3,6 +3,7 @@ package com.example.tripy.domain.tag;
 import com.example.tripy.domain.posttag.PostTag;
 import com.example.tripy.global.utils.BaseTimeEntity;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -26,7 +27,7 @@ public class Tag extends BaseTimeEntity {
     @NotNull
     private String tagName;
 
-    @OneToMany(mappedBy = "tag")
+    @OneToMany(mappedBy = "tag", fetch = FetchType.LAZY)
     private List<PostTag> postTags = new ArrayList<>();
 
 

--- a/src/main/java/com/example/tripy/domain/travelplan/TravelPlan.java
+++ b/src/main/java/com/example/tripy/domain/travelplan/TravelPlan.java
@@ -31,23 +31,23 @@ public class TravelPlan extends BaseTimeEntity {
     @Temporal(TemporalType.TIMESTAMP)
     private Date arrival;
 
-    @OneToMany(mappedBy = "travelPlan")
+    @OneToMany(mappedBy = "travelPlan", fetch = FetchType.LAZY)
     private List<CityPlan> cityPlans = new ArrayList<>();
 
-    @OneToMany(mappedBy = "travelPlan")
+    @OneToMany(mappedBy = "travelPlan", fetch = FetchType.LAZY)
     private List<Bag> bags = new ArrayList<>();
 
-    @OneToMany(mappedBy = "travelPlan")
+    @OneToMany(mappedBy = "travelPlan", fetch = FetchType.LAZY)
     private List<PlanFriend> planFriends = new ArrayList<>();
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 
-    @OneToMany(mappedBy = "travelPlan")
+    @OneToMany(mappedBy = "travelPlan", fetch = FetchType.LAZY)
     private List<Post> posts = new ArrayList<>();
 
-    @OneToMany(mappedBy = "travelPlan")
+    @OneToMany(mappedBy = "travelPlan", fetch = FetchType.LAZY)
     private List<TravelTimePlan> travelTimePlans = new ArrayList<>();
 
 }

--- a/src/main/java/com/example/tripy/domain/travelplan/TravelPlan.java
+++ b/src/main/java/com/example/tripy/domain/travelplan/TravelPlan.java
@@ -1,0 +1,53 @@
+package com.example.tripy.domain.travelplan;
+
+import com.example.tripy.domain.bag.Bag;
+import com.example.tripy.domain.cityplan.CityPlan;
+import com.example.tripy.domain.planfriend.PlanFriend;
+import com.example.tripy.domain.post.Post;
+import com.example.tripy.domain.traveltimeplan.TravelTimePlan;
+import com.example.tripy.domain.user.User;
+import com.example.tripy.global.utils.BaseTimeEntity;
+import jakarta.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+public class TravelPlan extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date departure;
+
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date arrival;
+
+    @OneToMany(mappedBy = "travelPlan")
+    private List<CityPlan> cityPlans = new ArrayList<>();
+
+    @OneToMany(mappedBy = "travelPlan")
+    private List<Bag> bags = new ArrayList<>();
+
+    @OneToMany(mappedBy = "travelPlan")
+    private List<PlanFriend> planFriends = new ArrayList<>();
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @OneToMany(mappedBy = "travelPlan")
+    private List<Post> posts = new ArrayList<>();
+
+    @OneToMany(mappedBy = "travelPlan")
+    private List<TravelTimePlan> travelTimePlans = new ArrayList<>();
+
+}

--- a/src/main/java/com/example/tripy/domain/travelplan/TravelPlanController.java
+++ b/src/main/java/com/example/tripy/domain/travelplan/TravelPlanController.java
@@ -1,9 +1,9 @@
-package com.example.tripy.domain.posttag;
+package com.example.tripy.domain.travelplan;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RestController
-public class PostTagController {
+public class TravelPlanController {
 }

--- a/src/main/java/com/example/tripy/domain/travelplan/TravelPlanRepository.java
+++ b/src/main/java/com/example/tripy/domain/travelplan/TravelPlanRepository.java
@@ -1,0 +1,6 @@
+package com.example.tripy.domain.travelplan;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TravelPlanRepository extends JpaRepository<TravelPlan, Long> {
+}

--- a/src/main/java/com/example/tripy/domain/travelplan/TravelPlanService.java
+++ b/src/main/java/com/example/tripy/domain/travelplan/TravelPlanService.java
@@ -1,0 +1,9 @@
+package com.example.tripy.domain.travelplan;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class TravelPlanService {
+}

--- a/src/main/java/com/example/tripy/domain/traveltimeplan/TravelTimePlan.java
+++ b/src/main/java/com/example/tripy/domain/traveltimeplan/TravelTimePlan.java
@@ -1,0 +1,61 @@
+package com.example.tripy.domain.traveltimeplan;
+
+import com.example.tripy.domain.travelplan.TravelPlan;
+import com.example.tripy.global.utils.BaseTimeEntity;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder.Default;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+public class TravelTimePlan extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    private String color;
+
+    @NotNull
+    private String line_color;
+
+    @NotNull
+    private String title;
+
+    @NotNull
+    private int column;
+
+    @NotNull
+    private LocalTime departure;
+
+    @NotNull
+    private int halfHourReputationCount;
+
+    private String place;
+
+    private String budget;
+
+    private String memo;
+
+    private String image_url;
+
+    private String plan_url;
+
+    @NotNull
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date date;
+
+    @ManyToOne
+    @JoinColumn(name = "travelplan_id")
+    private TravelPlan travelPlan;
+
+
+}

--- a/src/main/java/com/example/tripy/domain/traveltimeplan/TravelTimePlan.java
+++ b/src/main/java/com/example/tripy/domain/traveltimeplan/TravelTimePlan.java
@@ -52,7 +52,7 @@ public class TravelTimePlan extends BaseTimeEntity {
     @Temporal(TemporalType.TIMESTAMP)
     private Date date;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "travelplan_id")
     private TravelPlan travelPlan;
 

--- a/src/main/java/com/example/tripy/domain/traveltimeplan/TravelTimePlan.java
+++ b/src/main/java/com/example/tripy/domain/traveltimeplan/TravelTimePlan.java
@@ -45,9 +45,9 @@ public class TravelTimePlan extends BaseTimeEntity {
 
     private String memo;
 
-    private String image_url;
+    private String imageUrl;
 
-    private String plan_url;
+    private String planUrl;
 
     @NotNull
     @Temporal(TemporalType.TIMESTAMP)

--- a/src/main/java/com/example/tripy/domain/traveltimeplan/TravelTimePlan.java
+++ b/src/main/java/com/example/tripy/domain/traveltimeplan/TravelTimePlan.java
@@ -6,7 +6,6 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalTime;
 import lombok.AllArgsConstructor;
-import lombok.Builder.Default;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -25,7 +24,7 @@ public class TravelTimePlan extends BaseTimeEntity {
     private String color;
 
     @NotNull
-    private String line_color;
+    private String lineColor;
 
     @NotNull
     private String title;

--- a/src/main/java/com/example/tripy/domain/traveltimeplan/TravelTimePlanController.java
+++ b/src/main/java/com/example/tripy/domain/traveltimeplan/TravelTimePlanController.java
@@ -1,9 +1,9 @@
-package com.example.tripy.domain.posttag;
+package com.example.tripy.domain.traveltimeplan;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RestController
-public class PostTagController {
+public class TravelTimePlanController {
 }

--- a/src/main/java/com/example/tripy/domain/traveltimeplan/TravelTimePlanRepository.java
+++ b/src/main/java/com/example/tripy/domain/traveltimeplan/TravelTimePlanRepository.java
@@ -1,0 +1,6 @@
+package com.example.tripy.domain.traveltimeplan;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TravelTimePlanRepository extends JpaRepository<TravelTimePlan, Long> {
+}

--- a/src/main/java/com/example/tripy/domain/traveltimeplan/TravelTimePlanService.java
+++ b/src/main/java/com/example/tripy/domain/traveltimeplan/TravelTimePlanService.java
@@ -1,0 +1,9 @@
+package com.example.tripy.domain.traveltimeplan;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class TravelTimePlanService {
+}

--- a/src/main/java/com/example/tripy/domain/user/User.java
+++ b/src/main/java/com/example/tripy/domain/user/User.java
@@ -7,6 +7,7 @@ import com.example.tripy.domain.post.Post;
 import com.example.tripy.domain.travelplan.TravelPlan;
 import com.example.tripy.global.utils.BaseTimeEntity;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -47,22 +48,22 @@ public class User extends BaseTimeEntity {
 
     private Long naverToken;
 
-    @OneToMany(mappedBy = "user")
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
     private List<Post> posts = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user")
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
     private List<Bag> bags = new ArrayList<>();
 
-    @OneToMany(mappedBy = "fromUser")
+    @OneToMany(mappedBy = "fromUser", fetch = FetchType.LAZY)
     private List<Friend> sentRequests = new ArrayList<>();
 
-    @OneToMany(mappedBy = "toUser")
+    @OneToMany(mappedBy = "toUser", fetch = FetchType.LAZY)
     private List<Friend> receivedRequests = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user")
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
     private List<PlanFriend> planFriends = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user")
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
     private List<TravelPlan> travelPlans = new ArrayList<>();
 
 

--- a/src/main/java/com/example/tripy/domain/user/User.java
+++ b/src/main/java/com/example/tripy/domain/user/User.java
@@ -40,13 +40,13 @@ public class User extends BaseTimeEntity {
 
     private String profileImgUrl;
 
-    private Long kakaoToken;
+    private String kakaoToken;
 
-    private Long googleToken;
+    private String googleToken;
 
-    private Long appleToken;
+    private String appleToken;
 
-    private Long naverToken;
+    private String naverToken;
 
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
     private List<Post> posts = new ArrayList<>();

--- a/src/main/java/com/example/tripy/domain/user/User.java
+++ b/src/main/java/com/example/tripy/domain/user/User.java
@@ -1,0 +1,70 @@
+package com.example.tripy.domain.user;
+
+import com.example.tripy.domain.bag.Bag;
+import com.example.tripy.domain.friend.Friend;
+import com.example.tripy.domain.planfriend.PlanFriend;
+import com.example.tripy.domain.post.Post;
+import com.example.tripy.domain.travelplan.TravelPlan;
+import com.example.tripy.global.utils.BaseTimeEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+public class User extends BaseTimeEntity {
+
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    private String nickName;
+
+    @NotNull
+    private String email;
+
+    private String profileImgUrl;
+
+    private Long kakaoToken;
+
+    private Long googleToken;
+
+    private Long appleToken;
+
+    private Long naverToken;
+
+    @OneToMany(mappedBy = "user")
+    private List<Post> posts = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user")
+    private List<Bag> bags = new ArrayList<>();
+
+    @OneToMany(mappedBy = "fromUser")
+    private List<Friend> sentRequests = new ArrayList<>();
+
+    @OneToMany(mappedBy = "toUser")
+    private List<Friend> receivedRequests = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user")
+    private List<PlanFriend> planFriends = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user")
+    private List<TravelPlan> travelPlans = new ArrayList<>();
+
+
+
+}

--- a/src/main/java/com/example/tripy/domain/user/UserRepository.java
+++ b/src/main/java/com/example/tripy/domain/user/UserRepository.java
@@ -1,0 +1,6 @@
+package com.example.tripy.domain.user;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/com/example/tripy/domain/user/UserService.java
+++ b/src/main/java/com/example/tripy/domain/user/UserService.java
@@ -1,0 +1,9 @@
+package com.example.tripy.domain.user;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class UserService {
+}

--- a/src/main/java/com/example/tripy/domain/user/UsserController.java
+++ b/src/main/java/com/example/tripy/domain/user/UsserController.java
@@ -1,9 +1,8 @@
-package com.example.tripy.domain.posttag;
+package com.example.tripy.domain.user;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RestController;
-
 @RequiredArgsConstructor
 @RestController
-public class PostTagController {
+public class UsserController {
 }


### PR DESCRIPTION
## 요약

- 설계 되어있는 ERD 기반으로 entity 매핑을 진행하였습니다. 
- 도메인 디렉터리를 생성하였습니다. 

## 상세 내용
bag
bagMaterials
city
cityPlan
continent
conversation
country
countryMaterial
currency
friend
landmark
materials
planFriends
post
postFile
postTag
tag
timePlan
travelPlan
user
디렉토리 생성 및 엔티티 매핑

## 테스트 확인 내용


## 질문 및 이외 사항

- PlanFriend 테이블 매핑하는 부분에서 여러분들의 의견을 묻고싶은 부분이 생겼습니다. 
본래는 travelPlan(여행계획) 테이블과 Friend(친구) 테이블을 매핑하였는데(즉, 여행 게획과 친구 관계 인덱스를 매핑),
여행 계획에는 계획을 만든 user id가 존재하고, 이를 친구 관계 id와 매핑하는 부분이 이상하다고 생각해서 plan과 user 테이블을 매핑하도록 변경하였습니다. 
1. travelPlan 초대는 친구만 가능해서, 이 부분을 예외처리 하는 코드를 작성하는 방법
2. 복합키를 사용해서 PlanFriendId라는 별도의 복합키 클래스를 만들고, 이를 PlanFriend 엔티티의 @IdClass로 지정하는 방법
두 방법 중에 고민이 돼서, 여러분들의 의견을 듣고 싶습니다. 

우선 1번 방법으로 설계해서 올려놨습니다!

## 이슈 번호

- #9
