### PR TITLE
Feat: 환율정보 업데이트

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,12 +38,6 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
     implementation group: 'javax.xml.bind', name: 'jaxb-api', version: '2.3.1'
 
-    //oauth2-client
-    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-    //Oauth 서버와의 통신을 위한 webclient
-    implementation 'org.springframework.boot:spring-boot-starter-webflux'
-    //jwt
-    implementation 'io.jsonwebtoken:jjwt:0.9.1'
 
 }
 

--- a/src/main/java/com/example/tripy/domain/currency/CurrencyController.java
+++ b/src/main/java/com/example/tripy/domain/currency/CurrencyController.java
@@ -2,6 +2,7 @@ package com.example.tripy.domain.currency;
 
 import com.example.tripy.domain.currency.dto.CurrencyResponseDto;
 import com.example.tripy.domain.post.dto.PostResponseDto;
+import com.example.tripy.global.common.response.ApiResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -18,15 +19,15 @@ public class CurrencyController {
      * [GET] 전체 환율 조회
      */
     @GetMapping
-    public ResponseEntity<List<CurrencyResponseDto>> getCurrencyList(){
-        return ResponseEntity.ok(currencyService.getCurrencyList());
+    public ApiResponse<List<CurrencyResponseDto>> getCurrencyList(){
+        return ApiResponse.onSuccess(currencyService.getCurrencyList());
     }
 
     /**
      * [GET] 나라별 환율 조회
      */
     @GetMapping("/{countryId}")
-    public ResponseEntity<CurrencyResponseDto> getCurrencyByCountry(@PathVariable Long countryId){
-        return ResponseEntity.ok(currencyService.getCurrencyByCountryId(countryId));
+    public ApiResponse<CurrencyResponseDto> getCurrencyByCountry(@PathVariable Long countryId){
+        return ApiResponse.onSuccess(currencyService.getCurrencyByCountryId(countryId));
     }
 }

--- a/src/main/java/com/example/tripy/domain/currency/CurrencyService.java
+++ b/src/main/java/com/example/tripy/domain/currency/CurrencyService.java
@@ -5,6 +5,7 @@ import com.example.tripy.domain.country.CountryRepository;
 import com.example.tripy.domain.currency.dto.CurrencyResponseDto;
 import com.example.tripy.global.common.response.code.status.ErrorStatus;
 import com.example.tripy.global.common.response.exception.GeneralException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +21,7 @@ public class CurrencyService {
 
     public List<CurrencyResponseDto> getCurrencyList() {
         List<Currency> currencyList = currencyRepository.findAll();
+
         return currencyList.stream()
             .map(CurrencyResponseDto::toDTO)
             .collect(Collectors.toList());
@@ -29,10 +31,15 @@ public class CurrencyService {
         Country country = countryRepository.findById(countryId)
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_COUNTRY));
 
-        Currency currency = currencyRepository.findByCountryName(country.getName())
-            .orElseThrow(() -> new GeneralException(
-                ErrorStatus._EMPTY_CURRENCY));
+        String countryName = country.getName();
 
-        return CurrencyResponseDto.toDTO(currency);
+        if(countryName.equals("스페인") || countryName.equals("프랑스")){
+            countryName = "유로";
+        }
+
+        Currency currency = currencyRepository.findByCountryName(countryName)
+            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_CURRENCY));
+
+        return CurrencyResponseDto.euroToDto(currency, countryName);
     }
 }

--- a/src/main/java/com/example/tripy/domain/currency/dto/CurrencyResponseDto.java
+++ b/src/main/java/com/example/tripy/domain/currency/dto/CurrencyResponseDto.java
@@ -24,10 +24,20 @@ public class CurrencyResponseDto {
     public static CurrencyResponseDto toDTO(Currency entity){
         return CurrencyResponseDto.builder()
             .id(entity.getId())
+            .deal(entity.getDeal())
             .currencyUnit(entity.getCurrencyUnit())
             .currencyName(entity.getCurrencyName())
-            .deal(entity.getDeal())
             .countryName(entity.getCountryName())
+            .build();
+    }
+
+    public static CurrencyResponseDto euroToDto(Currency entity, String countryName){
+        return CurrencyResponseDto.builder()
+            .id(entity.getId())
+            .deal(entity.getDeal())
+            .currencyUnit(entity.getCurrencyUnit())
+            .currencyName(entity.getCurrencyName())
+            .countryName(countryName)
             .build();
     }
 }


### PR DESCRIPTION
## 요약
- 환율정보 전체 조회
- 환율정보 국가별 조회

## 상세 내용
- 환율 조회 로직을 작성하였습니다.
- 환율정보를 제공받는 OpenAPI의 response값에서 유로로 묶이는 나라의 경우에는 국가 이름이 명시되지 않습니다.
- 따라서 서비스 단에서 국가 이름으로 유로가 넘어왔을 상황을 처리하였습니다.
- 현재 우리의 서비스에서 유로를 사용하는 국가는 "프랑스"와 "스페인"이므로 해당 경우만 예외처리를 해주었습니다.
- 자세한 내용은 아래 링크에 정리해두었습니다.
https://velog.io/@gnstjdqkr/%ED%99%98%EC%9C%A8%EC%97%85%EB%8D%B0%EC%9D%B4%ED%8A%B8

## 질문 및 이외 사항
- 환율정보를 업로드하는 로직은 로컬 IDE환경에서 작성하였습니다.
- 환율 정보는 외부 OpenAPI 에서 호출하여 파싱하였습니다.
- 이후 Lambda와 EventBridge를 사용하여 자동화할 예정입니다.


## 이슈 번호