### PR TITLE
Feat: 여행 일정에 해당하는 가방 목록 생성하기

### DIFF
--- a/src/main/java/com/example/tripy/domain/bag/Bag.java
+++ b/src/main/java/com/example/tripy/domain/bag/Bag.java
@@ -1,8 +1,7 @@
 package com.example.tripy.domain.bag;
 
-import com.example.tripy.domain.bagmaterials.BagMaterials;
-import com.example.tripy.domain.travelplan.TravelPlan;
 import com.example.tripy.domain.member.Member;
+import com.example.tripy.domain.travelplan.TravelPlan;
 import com.example.tripy.global.utils.BaseTimeEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -11,11 +10,9 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
 import jakarta.validation.constraints.NotNull;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -24,7 +21,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Entity
 public class Bag extends BaseTimeEntity {
-
 
 
     @Id
@@ -46,5 +42,12 @@ public class Bag extends BaseTimeEntity {
     @JoinColumn(name = "travelplan_id")
     private TravelPlan travelPlan;
 
+    @Builder
+    public Bag(String bagName, String content, Member member, TravelPlan travelPlan) {
+        this.bagName = bagName;
+        this.content = content;
+        this.member = member;
+        this.travelPlan = travelPlan;
+    }
 
 }

--- a/src/main/java/com/example/tripy/domain/bag/BagController.java
+++ b/src/main/java/com/example/tripy/domain/bag/BagController.java
@@ -32,6 +32,9 @@ public class BagController {
         return ApiResponse.onSuccess(bagService.getBagsList(page, size, memberId));
     }
 
+    /**
+     * [POST] 여행 목록에서 여행 가방 생성하기
+     */
     @PostMapping("/member/bag/{memberId}/{travelPlanId}")
     public ApiResponse<String> createBag(@PathVariable Long memberId, @PathVariable(value = "travelPlanId") Long travelPlanId) {
         return ApiResponse.onSuccess(bagService.createBag(memberId, travelPlanId));

--- a/src/main/java/com/example/tripy/domain/bag/BagController.java
+++ b/src/main/java/com/example/tripy/domain/bag/BagController.java
@@ -1,8 +1,6 @@
 package com.example.tripy.domain.bag;
 
 import com.example.tripy.domain.bag.dto.BagResponseDto.BagSimpleInfo;
-import com.example.tripy.domain.member.Member;
-import com.example.tripy.domain.member.enums.SocialType;
 import com.example.tripy.global.common.dto.PageResponseDto;
 import com.example.tripy.global.common.response.ApiResponse;
 import java.util.List;
@@ -36,7 +34,8 @@ public class BagController {
      * [POST] 여행 목록에서 여행 가방 생성하기
      */
     @PostMapping("/member/bag/{memberId}/{travelPlanId}")
-    public ApiResponse<String> createBag(@PathVariable Long memberId, @PathVariable(value = "travelPlanId") Long travelPlanId) {
+    public ApiResponse<String> createBag(@PathVariable Long memberId,
+        @PathVariable(value = "travelPlanId") Long travelPlanId) {
         return ApiResponse.onSuccess(bagService.createBag(memberId, travelPlanId));
     }
 

--- a/src/main/java/com/example/tripy/domain/bag/BagController.java
+++ b/src/main/java/com/example/tripy/domain/bag/BagController.java
@@ -7,11 +7,14 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RestController
+@RequestMapping("/travel-bag")
 public class BagController {
 
     private final BagService bagService;
@@ -19,11 +22,17 @@ public class BagController {
     /**
      * [GET] 내 여행 가방 모두 불러오기
      */
-    @GetMapping("travel-bag/member/bag/{memberId}")
+    @GetMapping("/member/bag/{memberId}")
     public ApiResponse<PageResponseDto<List<BagSimpleInfo>>> getBagsList(
         @PathVariable(value = "memberId") Long memberId, @RequestParam(value = "page") int page,
         @RequestParam(value = "size") int size) {
         return ApiResponse.onSuccess(bagService.getBagsList(page, size, memberId));
+    }
+
+    @PostMapping("/member/bag/{memberId}/{travelPlanId}")
+    public ApiResponse<String> createBag(@PathVariable(value = "memberId") Long memberId,
+        @PathVariable(value = "travelPlanId") Long travelPlanId) {
+        return ApiResponse.onSuccess(bagService.createBag(memberId, travelPlanId));
     }
 
 }

--- a/src/main/java/com/example/tripy/domain/bag/BagController.java
+++ b/src/main/java/com/example/tripy/domain/bag/BagController.java
@@ -21,9 +21,6 @@ public class BagController {
 
     private final BagService bagService;
 
-    private Member member = Member.builder()
-        .nickName("송민혁").email("email@email.com").password("test")
-        .profileImgUrl("test").socialType(SocialType.KAKAO).build();
 
     /**
      * [GET] 내 여행 가방 모두 불러오기
@@ -35,10 +32,9 @@ public class BagController {
         return ApiResponse.onSuccess(bagService.getBagsList(page, size, memberId));
     }
 
-    @PostMapping("/member/bag/{travelPlanId}")
-    public ApiResponse<String> createBag(Member member,
-        @PathVariable(value = "travelPlanId") Long travelPlanId) {
-        return ApiResponse.onSuccess(bagService.createBag(member, travelPlanId));
+    @PostMapping("/member/bag/{memberId}/{travelPlanId}")
+    public ApiResponse<String> createBag(@PathVariable Long memberId, @PathVariable(value = "travelPlanId") Long travelPlanId) {
+        return ApiResponse.onSuccess(bagService.createBag(memberId, travelPlanId));
     }
 
 }

--- a/src/main/java/com/example/tripy/domain/bag/BagController.java
+++ b/src/main/java/com/example/tripy/domain/bag/BagController.java
@@ -1,6 +1,8 @@
 package com.example.tripy.domain.bag;
 
 import com.example.tripy.domain.bag.dto.BagResponseDto.BagSimpleInfo;
+import com.example.tripy.domain.member.Member;
+import com.example.tripy.domain.member.enums.SocialType;
 import com.example.tripy.global.common.dto.PageResponseDto;
 import com.example.tripy.global.common.response.ApiResponse;
 import java.util.List;
@@ -19,6 +21,10 @@ public class BagController {
 
     private final BagService bagService;
 
+    private Member member = Member.builder()
+        .nickName("송민혁").email("email@email.com").password("test")
+        .profileImgUrl("test").socialType(SocialType.KAKAO).build();
+
     /**
      * [GET] 내 여행 가방 모두 불러오기
      */
@@ -29,10 +35,10 @@ public class BagController {
         return ApiResponse.onSuccess(bagService.getBagsList(page, size, memberId));
     }
 
-    @PostMapping("/member/bag/{memberId}/{travelPlanId}")
-    public ApiResponse<String> createBag(@PathVariable(value = "memberId") Long memberId,
+    @PostMapping("/member/bag/{travelPlanId}")
+    public ApiResponse<String> createBag(Member member,
         @PathVariable(value = "travelPlanId") Long travelPlanId) {
-        return ApiResponse.onSuccess(bagService.createBag(memberId, travelPlanId));
+        return ApiResponse.onSuccess(bagService.createBag(member, travelPlanId));
     }
 
 }

--- a/src/main/java/com/example/tripy/domain/bag/BagService.java
+++ b/src/main/java/com/example/tripy/domain/bag/BagService.java
@@ -3,6 +3,7 @@ package com.example.tripy.domain.bag;
 import com.example.tripy.domain.bag.dto.BagResponseDto.BagSimpleInfo;
 import com.example.tripy.domain.cityplan.CityPlanRepository;
 import com.example.tripy.global.common.dto.PageResponseDto;
+import jakarta.transaction.Transactional;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -50,5 +51,10 @@ public class BagService {
                 .collect(Collectors.toList())));
     }
 
+    @Transactional
+    public String createBag(Long memberId, Long travelPlanId) {
+
+        return "가방 생성 완료";
+    }
 
 }

--- a/src/main/java/com/example/tripy/domain/bag/BagService.java
+++ b/src/main/java/com/example/tripy/domain/bag/BagService.java
@@ -66,7 +66,7 @@ public class BagService {
         Member member = memberRepository.findById(memberId)
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_MEMBER));
 
-        TravelPlan travelPlan = travelPlanRepository.findByMemberAndId(member,travelPlanId)
+        TravelPlan travelPlan = travelPlanRepository.findByMemberAndId(member, travelPlanId)
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_TRAVELPLAN));
         travelPlan.updateBagExists();
 

--- a/src/main/java/com/example/tripy/domain/bag/BagService.java
+++ b/src/main/java/com/example/tripy/domain/bag/BagService.java
@@ -68,7 +68,8 @@ public class BagService {
             .bagName("캐리어")
             .content("test")
             .member(member)
-            .travelPlan(travelPlanRepository.getReferenceById(travelPlanId))
+            .travelPlan(travelPlanRepository.findById(travelPlanId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_TRAVELPLAN)))
             .build();
 
         bagRepository.save(bag);

--- a/src/main/java/com/example/tripy/domain/bag/BagService.java
+++ b/src/main/java/com/example/tripy/domain/bag/BagService.java
@@ -4,6 +4,7 @@ import com.example.tripy.domain.bag.dto.BagResponseDto.BagSimpleInfo;
 import com.example.tripy.domain.cityplan.CityPlanRepository;
 import com.example.tripy.domain.member.Member;
 import com.example.tripy.domain.member.MemberRepository;
+import com.example.tripy.domain.travelplan.TravelPlan;
 import com.example.tripy.domain.travelplan.TravelPlanRepository;
 import com.example.tripy.global.common.dto.PageResponseDto;
 import com.example.tripy.global.common.response.code.status.ErrorStatus;
@@ -61,19 +62,15 @@ public class BagService {
     @Transactional
     public String createBag(Long memberId, Long travelPlanId) {
 
+        //Member 관련 메서드가 추가되면 수정 예정
         Member member = memberRepository.findById(memberId)
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_MEMBER));
 
-        Bag bag = Bag.builder()
-            .bagName("캐리어")
-            .content("test")
-            .member(member)
-            .travelPlan(travelPlanRepository.findById(travelPlanId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_TRAVELPLAN)))
-            .build();
+        TravelPlan travelPlan = travelPlanRepository.findByMemberAndId(member,travelPlanId)
+            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_TRAVELPLAN));
+        travelPlan.updateBagExists();
 
-        bagRepository.save(bag);
-        return "가방 생성 완료";
+        return "내 가방 목록에 추가 완료";
     }
 
 }

--- a/src/main/java/com/example/tripy/domain/bag/BagService.java
+++ b/src/main/java/com/example/tripy/domain/bag/BagService.java
@@ -2,6 +2,8 @@ package com.example.tripy.domain.bag;
 
 import com.example.tripy.domain.bag.dto.BagResponseDto.BagSimpleInfo;
 import com.example.tripy.domain.cityplan.CityPlanRepository;
+import com.example.tripy.domain.member.Member;
+import com.example.tripy.domain.travelplan.TravelPlanRepository;
 import com.example.tripy.global.common.dto.PageResponseDto;
 import jakarta.transaction.Transactional;
 import java.util.List;
@@ -18,6 +20,7 @@ public class BagService {
 
     private final BagRepository bagRepository;
     private final CityPlanRepository cityPlanRepository;
+    private final TravelPlanRepository travelPlanRepository;
 
     // Bag에 대한 간단한 일정 정보 Dto에 매핑
     public List<BagSimpleInfo> setBagSimpleInfo(List<Bag> bags) {
@@ -52,8 +55,16 @@ public class BagService {
     }
 
     @Transactional
-    public String createBag(Long memberId, Long travelPlanId) {
+    public String createBag(Member member, Long travelPlanId) {
 
+        Bag bag = Bag.builder()
+            .bagName("캐리어")
+            .content("test")
+            .member(member)
+            .travelPlan(travelPlanRepository.getReferenceById(travelPlanId))
+            .build();
+
+        bagRepository.save(bag);
         return "가방 생성 완료";
     }
 

--- a/src/main/java/com/example/tripy/domain/bag/BagService.java
+++ b/src/main/java/com/example/tripy/domain/bag/BagService.java
@@ -66,8 +66,10 @@ public class BagService {
         Member member = memberRepository.findById(memberId)
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_MEMBER));
 
-        TravelPlan travelPlan = travelPlanRepository.findByMemberAndId(member, travelPlanId)
-            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_TRAVELPLAN));
+        //bagExists 값이 False인 TravelPlan만 가능, 이미 가방이 존재하면 예외 처리
+        TravelPlan travelPlan = travelPlanRepository.findByMemberAndIdAndBagExistsIsFalse(member,
+                travelPlanId)
+            .orElseThrow(() -> new GeneralException(ErrorStatus._ALREADY_TRAVEL_PLAN_BAG_EXISTS));
         travelPlan.updateBagExists();
 
         return "내 가방 목록에 추가 완료";

--- a/src/main/java/com/example/tripy/domain/bag/BagService.java
+++ b/src/main/java/com/example/tripy/domain/bag/BagService.java
@@ -3,8 +3,11 @@ package com.example.tripy.domain.bag;
 import com.example.tripy.domain.bag.dto.BagResponseDto.BagSimpleInfo;
 import com.example.tripy.domain.cityplan.CityPlanRepository;
 import com.example.tripy.domain.member.Member;
+import com.example.tripy.domain.member.MemberRepository;
 import com.example.tripy.domain.travelplan.TravelPlanRepository;
 import com.example.tripy.global.common.dto.PageResponseDto;
+import com.example.tripy.global.common.response.code.status.ErrorStatus;
+import com.example.tripy.global.common.response.exception.GeneralException;
 import jakarta.transaction.Transactional;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -21,6 +24,7 @@ public class BagService {
     private final BagRepository bagRepository;
     private final CityPlanRepository cityPlanRepository;
     private final TravelPlanRepository travelPlanRepository;
+    private final MemberRepository memberRepository;
 
     // Bag에 대한 간단한 일정 정보 Dto에 매핑
     public List<BagSimpleInfo> setBagSimpleInfo(List<Bag> bags) {
@@ -55,7 +59,10 @@ public class BagService {
     }
 
     @Transactional
-    public String createBag(Member member, Long travelPlanId) {
+    public String createBag(Long memberId, Long travelPlanId) {
+
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_MEMBER));
 
         Bag bag = Bag.builder()
             .bagName("캐리어")

--- a/src/main/java/com/example/tripy/domain/member/Member.java
+++ b/src/main/java/com/example/tripy/domain/member/Member.java
@@ -1,22 +1,14 @@
 package com.example.tripy.domain.member;
 
-import com.example.tripy.domain.bag.Bag;
-import com.example.tripy.domain.friend.Friend;
 import com.example.tripy.domain.member.enums.SocialType;
-import com.example.tripy.domain.planfriend.PlanFriend;
-import com.example.tripy.domain.post.Post;
-import com.example.tripy.domain.travelplan.TravelPlan;
 import com.example.tripy.global.utils.BaseTimeEntity;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
 import jakarta.validation.constraints.NotNull;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -24,6 +16,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity
+@Builder
 public class Member extends BaseTimeEntity {
 
 
@@ -43,7 +36,6 @@ public class Member extends BaseTimeEntity {
     private String profileImgUrl;
 
     private SocialType socialType;
-
 
 
 }

--- a/src/main/java/com/example/tripy/domain/travelplan/TravelPlan.java
+++ b/src/main/java/com/example/tripy/domain/travelplan/TravelPlan.java
@@ -38,4 +38,8 @@ public class TravelPlan extends BaseTimeEntity {
     private Member member;
 
 
+    public void updateBagExists(){
+        //가방이 존재하지 않으면 true로 변경, 존재하면 false로 변경
+        this.bagExists = !this.bagExists;
+    }
 }

--- a/src/main/java/com/example/tripy/domain/travelplan/TravelPlan.java
+++ b/src/main/java/com/example/tripy/domain/travelplan/TravelPlan.java
@@ -11,7 +11,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Temporal;
 import jakarta.persistence.TemporalType;
-import jakarta.validation.constraints.NotNull;
 import java.util.Date;
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/example/tripy/domain/travelplan/TravelPlan.java
+++ b/src/main/java/com/example/tripy/domain/travelplan/TravelPlan.java
@@ -31,6 +31,8 @@ public class TravelPlan extends BaseTimeEntity {
     @Temporal(TemporalType.TIMESTAMP)
     private Date arrival;
 
+    private boolean bagExists; // 가방 존재 여부 확인
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;

--- a/src/main/java/com/example/tripy/domain/travelplan/TravelPlan.java
+++ b/src/main/java/com/example/tripy/domain/travelplan/TravelPlan.java
@@ -1,26 +1,28 @@
 package com.example.tripy.domain.travelplan;
 
-import com.example.tripy.domain.bag.Bag;
-import com.example.tripy.domain.cityplan.CityPlan;
-import com.example.tripy.domain.planfriend.PlanFriend;
-import com.example.tripy.domain.post.Post;
-import com.example.tripy.domain.traveltimeplan.TravelTimePlan;
 import com.example.tripy.domain.member.Member;
 import com.example.tripy.global.utils.BaseTimeEntity;
-import jakarta.persistence.*;
-import java.util.ArrayList;
-import java.util.List;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
+import jakarta.validation.constraints.NotNull;
+import java.util.Date;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.Date;
 
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity
 public class TravelPlan extends BaseTimeEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -31,14 +33,14 @@ public class TravelPlan extends BaseTimeEntity {
     @Temporal(TemporalType.TIMESTAMP)
     private Date arrival;
 
-    private boolean bagExists; // 가방 존재 여부 확인
+    private Boolean bagExists = false; // 가방 존재 여부 확인
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
 
-    public void updateBagExists(){
+    public void updateBagExists() {
         //가방이 존재하지 않으면 true로 변경, 존재하면 false로 변경
         this.bagExists = !this.bagExists;
     }

--- a/src/main/java/com/example/tripy/domain/travelplan/TravelPlanRepository.java
+++ b/src/main/java/com/example/tripy/domain/travelplan/TravelPlanRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TravelPlanRepository extends JpaRepository<TravelPlan, Long> {
 
-    Optional<TravelPlan> findByMemberAndId(Member member, Long id);
+    Optional<TravelPlan> findByMemberAndIdAndBagExistsIsFalse(Member member, Long id);
 }

--- a/src/main/java/com/example/tripy/domain/travelplan/TravelPlanRepository.java
+++ b/src/main/java/com/example/tripy/domain/travelplan/TravelPlanRepository.java
@@ -1,6 +1,10 @@
 package com.example.tripy.domain.travelplan;
 
+import com.example.tripy.domain.member.Member;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TravelPlanRepository extends JpaRepository<TravelPlan, Long> {
+
+    Optional<TravelPlan> findByMemberAndId(Member member, Long id);
 }

--- a/src/main/java/com/example/tripy/global/common/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/tripy/global/common/response/code/status/ErrorStatus.java
@@ -11,8 +11,8 @@ import org.springframework.http.HttpStatus;
 public enum ErrorStatus implements BaseErrorCode {
     //일반 응답
     _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
-    _BAD_REQUEST(HttpStatus.BAD_REQUEST,"COMMON400","잘못된 요청입니다."),
-    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
+    _BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
+    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
 
     //멤버 관련
@@ -29,7 +29,9 @@ public enum ErrorStatus implements BaseErrorCode {
     _EMPTY_COUNTRY(HttpStatus.CONFLICT, "CTR_001", "국가정보가 존재하지 않습니다."),
 
     // TravelPlan 관련
-    _EMPTY_TRAVELPLAN(HttpStatus.NOT_FOUND, "TRAVEL_PLAN_001","존재하지 않는 여행 계획입니다.");
+    _EMPTY_TRAVEL_PLAN(HttpStatus.NOT_FOUND, "TRAVEL_PLAN_001", "존재하지 않는 여행 계획입니다."),
+    _ALREADY_TRAVEL_PLAN_BAG_EXISTS(HttpStatus.BAD_REQUEST, "TRAVEL_PLAN_002",
+        "이미 가방이 존재하는 여행 계획입니다.");
 
 
     private final HttpStatus httpStatus;
@@ -39,10 +41,10 @@ public enum ErrorStatus implements BaseErrorCode {
     @Override
     public ErrorReasonDto getReasonHttpStatus() {
         return ErrorReasonDto.builder()
-                .message(message)
-                .code(code)
-                .isSuccess(false)
-                .httpStatus(httpStatus)
-                .build();
+            .message(message)
+            .code(code)
+            .isSuccess(false)
+            .httpStatus(httpStatus)
+            .build();
     }
 }

--- a/src/main/java/com/example/tripy/global/common/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/tripy/global/common/response/code/status/ErrorStatus.java
@@ -26,8 +26,10 @@ public enum ErrorStatus implements BaseErrorCode {
     _EMPTY_CURRENCY(HttpStatus.CONFLICT, "CUR_001", "환율정보가 존재하지 않습니다."),
 
     //나라 관련
-    _EMPTY_COUNTRY(HttpStatus.CONFLICT, "CTR_001", "국가정보가 존재하지 않습니다.")
-    ;
+    _EMPTY_COUNTRY(HttpStatus.CONFLICT, "CTR_001", "국가정보가 존재하지 않습니다."),
+
+    // TravelPlan 관련
+    _EMPTY_TRAVELPLAN(HttpStatus.NOT_FOUND, "TRAVEL_PLAN_001","존재하지 않는 여행 계획입니다.");
 
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 요약

- 여행 일정에 해당하는 가방 목록을 생성하기를 구현

## 상세 내용
![image](https://github.com/UMC-TRIPY/back-end-spring/assets/125117389/3fc3d66a-1921-4a78-acc9-27e4d63e694b)
위 사진에서, 해당 일정에서 가방 생성하기를 누르면 작동하는 API에 대한 구현입니다.

### TravelPlan Entity
- `private Boolean bagExists = false;` : 해당 컬럼을 추가하여 TravelPlan에 가방이 존재하는 지 확인합니다. 
- `updateBagExists` : 해당 메소드를 통해 상태 변경
```java
public void updateBagExists() {
        //가방이 존재하지 않으면 true로 변경, 존재하면 false로 변경
        this.bagExists = !this.bagExists;
    }
```

## 테스트 확인 내용

```json
{
  "isSuccess": true,
  "code": "COMMON200",
  "message": "성공입니다.",
  "result": "내 가방 목록에 추가 완료"
}
```
- 실행 결과는 위에 같습니다.
```json
{
  "isSuccess": false,
  "code": "TRAVEL_PLAN_002",
  "message": "이미 가방이 존재하는 여행 계획입니다."
}
```
- 이미 가방이 존재 할 경우, 해당 에러가 발생합니다.

## 질문 및 이외 사항

- Member 관련 메서드가 추가하면 수정하도록 하겠습니다!

## 이슈 번호

- close #25 
