### PR TITLE
FEAT : 커뮤니티 글 조회

### DIFF
--- a/src/main/java/com/example/tripy/TripyApplication.java
+++ b/src/main/java/com/example/tripy/TripyApplication.java
@@ -2,10 +2,12 @@ package com.example.tripy;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableScheduling
 @SpringBootApplication
+@EnableJpaAuditing
 public class TripyApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/example/tripy/domain/post/Post.java
+++ b/src/main/java/com/example/tripy/domain/post/Post.java
@@ -42,6 +42,9 @@ public class Post extends BaseTimeEntity {
     @ColumnDefault("0")
     private Integer recommendationCount;
 
+    @ColumnDefault("0")
+    private int rank;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;

--- a/src/main/java/com/example/tripy/domain/post/Post.java
+++ b/src/main/java/com/example/tripy/domain/post/Post.java
@@ -1,6 +1,7 @@
 package com.example.tripy.domain.post;
 
 import com.example.tripy.domain.city.City;
+import com.example.tripy.domain.country.Country;
 import com.example.tripy.domain.member.Member;
 import com.example.tripy.domain.post.dto.PostRequestDto.CreatePostRequest;
 import com.example.tripy.domain.travelplan.TravelPlan;
@@ -56,6 +57,9 @@ public class Post extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "travelplan_id")
     private TravelPlan travelPlan;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Country country;
 
     public static Post toEntity(CreatePostRequest createPostRequest, Member member, City city
         , TravelPlan travelPlan) {

--- a/src/main/java/com/example/tripy/domain/post/PostController.java
+++ b/src/main/java/com/example/tripy/domain/post/PostController.java
@@ -1,9 +1,12 @@
 package com.example.tripy.domain.post;
 
 import com.example.tripy.domain.post.dto.PostRequestDto.CreatePostRequest;
+import com.example.tripy.domain.post.dto.PostResponseDto.GetPostSimpleInfo;
 import com.example.tripy.global.common.response.ApiResponse;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -36,5 +39,13 @@ public class PostController {
         @PathVariable   Long postsId) {
         postService.deletePost(postsId);
         return ApiResponse.onSuccess("글 삭제에 성공했습니다.");
+    }
+
+    /**
+     * [GET] 인기글 TOP 10 조회
+     */
+    @GetMapping("api/posts/top-ten")
+    public ApiResponse<List<GetPostSimpleInfo>> findPostsTopten() {
+        return ApiResponse.onSuccess(postService.findPostsTopten());
     }
 }

--- a/src/main/java/com/example/tripy/domain/post/PostController.java
+++ b/src/main/java/com/example/tripy/domain/post/PostController.java
@@ -47,9 +47,10 @@ public class PostController {
      */
     @GetMapping("api/posts/top")
     public ApiResponse<List<GetPostSimpleInfo>> findPostsTopten(
+        @RequestParam Long countryId,
         @RequestParam int num
     ) {
-        return ApiResponse.onSuccess(postService.findPostsTop(num));
+        return ApiResponse.onSuccess(postService.findPostsTop(countryId, num));
     }
 
     /**

--- a/src/main/java/com/example/tripy/domain/post/PostController.java
+++ b/src/main/java/com/example/tripy/domain/post/PostController.java
@@ -1,6 +1,7 @@
 package com.example.tripy.domain.post;
 
 import com.example.tripy.domain.post.dto.PostRequestDto.CreatePostRequest;
+import com.example.tripy.domain.post.dto.PostResponseDto.GetPostDetailInfo;
 import com.example.tripy.domain.post.dto.PostResponseDto.GetPostSimpleInfo;
 import com.example.tripy.global.common.dto.PageResponseDto;
 import com.example.tripy.global.common.response.ApiResponse;
@@ -73,5 +74,13 @@ public class PostController {
         @RequestParam int page, @RequestParam int size
     ) {
         return ApiResponse.onSuccess(postService.findPostsLatest(countryId, page, size));
+    }
+
+    /**
+     * [GET] 게시글 상세 조회
+     */
+    @GetMapping("api/posts/{postsId}")
+    public ApiResponse<GetPostDetailInfo> findPost(@PathVariable Long postsId) {
+        return ApiResponse.onSuccess(postService.findPost(postsId));
     }
 }

--- a/src/main/java/com/example/tripy/domain/post/PostController.java
+++ b/src/main/java/com/example/tripy/domain/post/PostController.java
@@ -58,9 +58,10 @@ public class PostController {
      */
     @GetMapping("api/posts/top-recommended")
     public ApiResponse<PageResponseDto<List<GetPostSimpleInfo>>> findPostTopRecommended(
+        @RequestParam Long countryId,
         @RequestParam int page, @RequestParam int size
     ) {
-        return ApiResponse.onSuccess(postService.findPostsTopRecommended(page, size));
+        return ApiResponse.onSuccess(postService.findPostsTopRecommended(countryId, page, size));
     }
 
     /**
@@ -68,8 +69,9 @@ public class PostController {
      */
     @GetMapping("api/posts/latest")
     public ApiResponse<PageResponseDto<List<GetPostSimpleInfo>>> findPostLatest(
+        @RequestParam Long countryId,
         @RequestParam int page, @RequestParam int size
     ) {
-        return ApiResponse.onSuccess(postService.findPostsLatest(page, size));
+        return ApiResponse.onSuccess(postService.findPostsLatest(countryId, page, size));
     }
 }

--- a/src/main/java/com/example/tripy/domain/post/PostController.java
+++ b/src/main/java/com/example/tripy/domain/post/PostController.java
@@ -2,6 +2,7 @@ package com.example.tripy.domain.post;
 
 import com.example.tripy.domain.post.dto.PostRequestDto.CreatePostRequest;
 import com.example.tripy.domain.post.dto.PostResponseDto.GetPostSimpleInfo;
+import com.example.tripy.global.common.dto.PageResponseDto;
 import com.example.tripy.global.common.response.ApiResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -47,5 +48,15 @@ public class PostController {
     @GetMapping("api/posts/top-ten")
     public ApiResponse<List<GetPostSimpleInfo>> findPostsTopten() {
         return ApiResponse.onSuccess(postService.findPostsTopten());
+    }
+
+    /**
+     * [GET] 전체 글 추천 많은 순 조회
+     */
+    @GetMapping("api/posts/top-recommended")
+    public ApiResponse<PageResponseDto<List<GetPostSimpleInfo>>> findPostTopRecommended(
+        @RequestParam int page, @RequestParam int size
+    ) {
+        return ApiResponse.onSuccess(postService.findPostsTopRecommended(page, size));
     }
 }

--- a/src/main/java/com/example/tripy/domain/post/PostController.java
+++ b/src/main/java/com/example/tripy/domain/post/PostController.java
@@ -43,11 +43,13 @@ public class PostController {
     }
 
     /**
-     * [GET] 인기글 TOP 10 조회
+     * [GET] 인기글 TOP 조회
      */
-    @GetMapping("api/posts/top-ten")
-    public ApiResponse<List<GetPostSimpleInfo>> findPostsTopten() {
-        return ApiResponse.onSuccess(postService.findPostsTopten());
+    @GetMapping("api/posts/top")
+    public ApiResponse<List<GetPostSimpleInfo>> findPostsTopten(
+        @RequestParam int num
+    ) {
+        return ApiResponse.onSuccess(postService.findPostsTop(num));
     }
 
     /**
@@ -58,5 +60,15 @@ public class PostController {
         @RequestParam int page, @RequestParam int size
     ) {
         return ApiResponse.onSuccess(postService.findPostsTopRecommended(page, size));
+    }
+
+    /**
+     * [GET] 전체글 최신 순 조회
+     */
+    @GetMapping("api/posts/latest")
+    public ApiResponse<PageResponseDto<List<GetPostSimpleInfo>>> findPostLatest(
+        @RequestParam int page, @RequestParam int size
+    ) {
+        return ApiResponse.onSuccess(postService.findPostsLatest(page, size));
     }
 }

--- a/src/main/java/com/example/tripy/domain/post/PostRepository.java
+++ b/src/main/java/com/example/tripy/domain/post/PostRepository.java
@@ -1,8 +1,12 @@
 package com.example.tripy.domain.post;
 
+import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
-//    List<Post> findByCountry(Long countryId);
 
+    @Query("SELECT p FROM Post p WHERE p.rank > 0 ORDER BY p.rank ASC limit 10")
+    List<Post> findByRankToptenOrderByRank(Pageable pageable);
 }

--- a/src/main/java/com/example/tripy/domain/post/PostRepository.java
+++ b/src/main/java/com/example/tripy/domain/post/PostRepository.java
@@ -9,8 +9,10 @@ import org.springframework.data.jpa.repository.Query;
 public interface PostRepository extends JpaRepository<Post, Long> {
 
     @Query("SELECT p FROM Post p WHERE p.rank > 0 ORDER BY p.rank ASC")
-    List<Post> findByRankToptenOrderByRank(Pageable pageable);
+    List<Post> findByRankTopOrderByRank(Pageable pageable);
 
     @Query("SELECT p FROM Post p ORDER BY p.recommendationCount DESC")
     Page<Post> findByTopRecommended(Pageable pageable);
+
+    Page<Post> findAllByOrderByCreatedAtDesc(Pageable pageable);
 }

--- a/src/main/java/com/example/tripy/domain/post/PostRepository.java
+++ b/src/main/java/com/example/tripy/domain/post/PostRepository.java
@@ -16,7 +16,14 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findByRankTopOrderByRankNotNullCountryId(@Param("countryId") Long countryId, Pageable pageable);
 
     @Query("SELECT p FROM Post p ORDER BY p.recommendationCount DESC")
-    Page<Post> findByTopRecommended(Pageable pageable);
+    Page<Post> findByTopRecommendedNullCountryId(Pageable pageable);
 
-    Page<Post> findAllByOrderByCreatedAtDesc(Pageable pageable);
+    @Query("SELECT p FROM Post p WHERE p.country.id = :countryId ORDER BY p.recommendationCount DESC")
+    Page<Post> findByTopRecommendedNotNullCountryId(@Param("countryId") Long countryId, Pageable pageable);
+
+    @Query("SELECT p FROM Post p ORDER BY p.createdAt DESC")
+    Page<Post> findAllByOrderByCreatedAtDescNullCountryId(Pageable pageable);
+
+    @Query("SELECT p FROM Post p WHERE p.country.id = :countryId ORDER BY p.createdAt DESC")
+    Page<Post> findAllByCountryIdAndOrderByCreatedAtDescNotNullCountryId(@Param("countryId") Long countryId, Pageable pageable);
 }

--- a/src/main/java/com/example/tripy/domain/post/PostRepository.java
+++ b/src/main/java/com/example/tripy/domain/post/PostRepository.java
@@ -5,11 +5,15 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
     @Query("SELECT p FROM Post p WHERE p.rank > 0 ORDER BY p.rank ASC")
-    List<Post> findByRankTopOrderByRank(Pageable pageable);
+    List<Post> findByRankTopOrderByRankNullCountryId(Pageable pageable);
+
+    @Query("SELECT p FROM Post p WHERE p.country.id = :countryId AND p.rank > 0 ORDER BY p.rank ASC")
+    List<Post> findByRankTopOrderByRankNotNullCountryId(@Param("countryId") Long countryId, Pageable pageable);
 
     @Query("SELECT p FROM Post p ORDER BY p.recommendationCount DESC")
     Page<Post> findByTopRecommended(Pageable pageable);

--- a/src/main/java/com/example/tripy/domain/post/PostRepository.java
+++ b/src/main/java/com/example/tripy/domain/post/PostRepository.java
@@ -1,12 +1,16 @@
 package com.example.tripy.domain.post;
 
 import java.util.List;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
-    @Query("SELECT p FROM Post p WHERE p.rank > 0 ORDER BY p.rank ASC limit 10")
+    @Query("SELECT p FROM Post p WHERE p.rank > 0 ORDER BY p.rank ASC")
     List<Post> findByRankToptenOrderByRank(Pageable pageable);
+
+    @Query("SELECT p FROM Post p ORDER BY p.recommendationCount DESC")
+    Page<Post> findByTopRecommended(Pageable pageable);
 }

--- a/src/main/java/com/example/tripy/domain/post/PostService.java
+++ b/src/main/java/com/example/tripy/domain/post/PostService.java
@@ -107,9 +107,18 @@ public class PostService {
     }
 
     //추천순 조회
-    public PageResponseDto<List<GetPostSimpleInfo>> findPostsTopRecommended(int page, int size) {
+    public PageResponseDto<List<GetPostSimpleInfo>> findPostsTopRecommended(Long countryId, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
-        Page<Post> postList = postRepository.findByTopRecommended(pageable);
+        Page<Post> postList;
+
+        //전체 조회
+        if(countryId == null) {
+            postList = postRepository.findByTopRecommendedNullCountryId(pageable);
+        }
+        //나라별 조회
+        else {
+            postList = postRepository.findByTopRecommendedNotNullCountryId(countryId, pageable);
+        }
 
         List<GetPostSimpleInfo> postDtoList = postList.stream()
             .map(GetPostSimpleInfo::toDto)
@@ -120,9 +129,18 @@ public class PostService {
     }
 
     //최신순 조회
-    public PageResponseDto<List<GetPostSimpleInfo>> findPostsLatest(int page, int size) {
+    public PageResponseDto<List<GetPostSimpleInfo>> findPostsLatest(Long countryId, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
-        Page<Post> postList = postRepository.findAllByOrderByCreatedAtDesc(pageable);
+        Page<Post> postList;
+
+        //전체 조회
+        if(countryId == null) {
+            postList = postRepository.findAllByOrderByCreatedAtDescNullCountryId(pageable);
+        }
+        //나라별 조회
+        else {
+            postList = postRepository.findByTopRecommendedNotNullCountryId(countryId, pageable);
+        }
 
         List<GetPostSimpleInfo> postDtoList = postList.stream()
             .map(GetPostSimpleInfo::toDto)

--- a/src/main/java/com/example/tripy/domain/post/PostService.java
+++ b/src/main/java/com/example/tripy/domain/post/PostService.java
@@ -5,6 +5,7 @@ import com.example.tripy.domain.city.CityRepository;
 import com.example.tripy.domain.member.Member;
 import com.example.tripy.domain.member.MemberRepository;
 import com.example.tripy.domain.post.dto.PostRequestDto.CreatePostRequest;
+import com.example.tripy.domain.post.dto.PostResponseDto.GetPostSimpleInfo;
 import com.example.tripy.domain.postfile.FileType;
 import com.example.tripy.domain.postfile.PostFileService;
 import com.example.tripy.domain.posttag.PostTagService;
@@ -15,6 +16,8 @@ import com.example.tripy.global.common.response.exception.GeneralException;
 import jakarta.transaction.Transactional;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
@@ -79,5 +82,15 @@ public class PostService {
         postTagService.deletePostTagsByPost(post);
 
         postRepository.delete(post);
+    }
+
+    public List<GetPostSimpleInfo> findPostsTopten() {
+
+        Pageable pageable = PageRequest.of(0, 10);
+        List<Post> postList = postRepository.findByRankToptenOrderByRank(pageable);
+
+        return postList.stream()
+            .map(GetPostSimpleInfo::toDto)
+            .toList();
     }
 }

--- a/src/main/java/com/example/tripy/domain/post/PostService.java
+++ b/src/main/java/com/example/tripy/domain/post/PostService.java
@@ -86,11 +86,11 @@ public class PostService {
         postRepository.delete(post);
     }
 
-    //TOP 10 조회
-    public List<GetPostSimpleInfo> findPostsTopten() {
+    //TOP 조회
+    public List<GetPostSimpleInfo> findPostsTop(int num) {
 
-        Pageable pageable = PageRequest.of(0, 10);
-        List<Post> postList = postRepository.findByRankToptenOrderByRank(pageable);
+        Pageable pageable = PageRequest.of(0, num);
+        List<Post> postList = postRepository.findByRankTopOrderByRank(pageable);
 
         return postList.stream()
             .map(GetPostSimpleInfo::toDto)
@@ -110,5 +110,17 @@ public class PostService {
         postDtoList);
     }
 
+    //최신순 조회
+    public PageResponseDto<List<GetPostSimpleInfo>> findPostsLatest(int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<Post> postList = postRepository.findAllByOrderByCreatedAtDesc(pageable);
+
+        List<GetPostSimpleInfo> postDtoList = postList.stream()
+            .map(GetPostSimpleInfo::toDto)
+            .toList();
+
+        return new PageResponseDto<>(postList.getNumber(), postList.getTotalPages(),
+            postDtoList);
+    }
 
 }

--- a/src/main/java/com/example/tripy/domain/post/PostService.java
+++ b/src/main/java/com/example/tripy/domain/post/PostService.java
@@ -5,6 +5,7 @@ import com.example.tripy.domain.city.CityRepository;
 import com.example.tripy.domain.member.Member;
 import com.example.tripy.domain.member.MemberRepository;
 import com.example.tripy.domain.post.dto.PostRequestDto.CreatePostRequest;
+import com.example.tripy.domain.post.dto.PostResponseDto.GetPostDetailInfo;
 import com.example.tripy.domain.post.dto.PostResponseDto.GetPostSimpleInfo;
 import com.example.tripy.domain.postfile.FileType;
 import com.example.tripy.domain.postfile.PostFileService;
@@ -33,6 +34,7 @@ public class PostService {
     private final MemberRepository memberRepository;
     private final PostTagService postTagService;
 
+    //게시글 추가
     @Transactional
     public void addPost(CreatePostRequest createPostRequest, Long travelPlanId, Long cityId) {
 
@@ -73,6 +75,7 @@ public class PostService {
         postTagService.savePostTag(post, tagIds);
     }
 
+    //게시글 삭제
     public void deletePost(Long postsId) {
         Member member = memberRepository.findById(1L)
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_MEMBER));
@@ -150,4 +153,15 @@ public class PostService {
             postDtoList);
     }
 
+    //게시글 단일 조회
+    public GetPostDetailInfo findPost(Long postsId) {
+        Post post = postRepository.findById(postsId)
+            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_POST));
+
+        List<String> imageUrls = postFileService.findImageFileUrlsByPostAndFileType(post, FileType.IMAGE);
+        List<String> fileUrls = postFileService.findImageFileUrlsByPostAndFileType(post, FileType.FILE);
+        List<String> postTags = postTagService.findTagsStringByPost(post);
+
+        return GetPostDetailInfo.toDto(post, imageUrls, fileUrls, postTags);
+    }
 }

--- a/src/main/java/com/example/tripy/domain/post/PostService.java
+++ b/src/main/java/com/example/tripy/domain/post/PostService.java
@@ -142,7 +142,7 @@ public class PostService {
         }
         //나라별 조회
         else {
-            postList = postRepository.findByTopRecommendedNotNullCountryId(countryId, pageable);
+            postList = postRepository.findAllByCountryIdAndOrderByCreatedAtDescNotNullCountryId(countryId, pageable);
         }
 
         List<GetPostSimpleInfo> postDtoList = postList.stream()

--- a/src/main/java/com/example/tripy/domain/post/PostService.java
+++ b/src/main/java/com/example/tripy/domain/post/PostService.java
@@ -50,13 +50,13 @@ public class PostService {
         Post post = Post.toEntity(createPostRequest, member, city, travelPlan);
 
         postRepository.save(post);
-        if(createPostRequest.getImageUrls() != null) {
+        if (createPostRequest.getImageUrls() != null) {
             addImages(post, createPostRequest.getImageUrls());
         }
-        if(createPostRequest.getFileUrls() != null) {
+        if (createPostRequest.getFileUrls() != null) {
             addFiles(post, createPostRequest.getFileUrls());
         }
-        if(createPostRequest.getTagIds() != null) {
+        if (createPostRequest.getTagIds() != null) {
             addTags(post, createPostRequest.getTagIds());
         }
     }
@@ -87,10 +87,19 @@ public class PostService {
     }
 
     //TOP 조회
-    public List<GetPostSimpleInfo> findPostsTop(int num) {
+    public List<GetPostSimpleInfo> findPostsTop(Long countryId, int num) {
 
         Pageable pageable = PageRequest.of(0, num);
-        List<Post> postList = postRepository.findByRankTopOrderByRank(pageable);
+
+        List<Post> postList;
+        // 전체 조회
+        if (countryId == null) {
+            postList = postRepository.findByRankTopOrderByRankNullCountryId(pageable);
+        }
+        //나라별 조회
+        else {
+            postList = postRepository.findByRankTopOrderByRankNotNullCountryId(countryId, pageable);
+        }
 
         return postList.stream()
             .map(GetPostSimpleInfo::toDto)
@@ -107,7 +116,7 @@ public class PostService {
             .toList();
 
         return new PageResponseDto<>(postList.getNumber(), postList.getTotalPages(),
-        postDtoList);
+            postDtoList);
     }
 
     //최신순 조회

--- a/src/main/java/com/example/tripy/domain/post/PostService.java
+++ b/src/main/java/com/example/tripy/domain/post/PostService.java
@@ -11,11 +11,13 @@ import com.example.tripy.domain.postfile.PostFileService;
 import com.example.tripy.domain.posttag.PostTagService;
 import com.example.tripy.domain.travelplan.TravelPlan;
 import com.example.tripy.domain.travelplan.TravelPlanRepository;
+import com.example.tripy.global.common.dto.PageResponseDto;
 import com.example.tripy.global.common.response.code.status.ErrorStatus;
 import com.example.tripy.global.common.response.exception.GeneralException;
 import jakarta.transaction.Transactional;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -84,6 +86,7 @@ public class PostService {
         postRepository.delete(post);
     }
 
+    //TOP 10 조회
     public List<GetPostSimpleInfo> findPostsTopten() {
 
         Pageable pageable = PageRequest.of(0, 10);
@@ -93,4 +96,19 @@ public class PostService {
             .map(GetPostSimpleInfo::toDto)
             .toList();
     }
+
+    //추천순 조회
+    public PageResponseDto<List<GetPostSimpleInfo>> findPostsTopRecommended(int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<Post> postList = postRepository.findByTopRecommended(pageable);
+
+        List<GetPostSimpleInfo> postDtoList = postList.stream()
+            .map(GetPostSimpleInfo::toDto)
+            .toList();
+
+        return new PageResponseDto<>(postList.getNumber(), postList.getTotalPages(),
+        postDtoList);
+    }
+
+
 }

--- a/src/main/java/com/example/tripy/domain/post/dto/PostResponseDto.java
+++ b/src/main/java/com/example/tripy/domain/post/dto/PostResponseDto.java
@@ -1,0 +1,33 @@
+package com.example.tripy.domain.post.dto;
+
+import com.example.tripy.domain.post.Post;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class PostResponseDto {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetPostSimpleInfo {
+
+        Long postId;
+        String cityName;
+        String title;
+        int recommendationCount;
+        Long viewCount;
+
+        public static GetPostSimpleInfo toDto(Post post) {
+            return GetPostSimpleInfo.builder()
+                .postId(post.getId())
+                .cityName(post.getCity().getName())
+                .title(post.getTitle())
+                .recommendationCount(post.getRecommendationCount())
+                .viewCount(post.getView())
+                .build();
+        }
+    }
+}

--- a/src/main/java/com/example/tripy/domain/post/dto/PostResponseDto.java
+++ b/src/main/java/com/example/tripy/domain/post/dto/PostResponseDto.java
@@ -1,6 +1,7 @@
 package com.example.tripy.domain.post.dto;
 
 import com.example.tripy.domain.post.Post;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -27,6 +28,40 @@ public class PostResponseDto {
                 .title(post.getTitle())
                 .recommendationCount(post.getRecommendationCount())
                 .viewCount(post.getView())
+                .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetPostDetailInfo {
+
+        private Long postId;
+        private String title;
+        private String nickname;
+        private String content;
+        private Long travelPlanId;
+        private List<String> imgUrls;
+        private List<String> fileUrls;
+        private List<String> postTags;
+        private Long viewCount;
+        private String createdAt;
+
+
+        public static GetPostDetailInfo toDto(Post post, List<String> imgUrls, List<String> fileUrls, List<String> postTags) {
+            return GetPostDetailInfo.builder()
+                .postId(post.getId())
+                .title(post.getTitle())
+                .nickname(post.getMember().getNickName())
+                .travelPlanId(post.getTravelPlan().getId())
+                .content(post.getContent())
+                .imgUrls(imgUrls)
+                .fileUrls(fileUrls)
+                .postTags(postTags)
+                .viewCount(post.getView())
+                .createdAt(String.valueOf(post.getCreatedAt()))
                 .build();
         }
     }

--- a/src/main/java/com/example/tripy/domain/postfile/PostFileRepository.java
+++ b/src/main/java/com/example/tripy/domain/postfile/PostFileRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface PostFileRepository extends JpaRepository<PostFile, Long> {
 
     List<PostFile> findAllByPost(Post post);
+
+    List<PostFile> findAllByPostAndFileType(Post post, FileType fileType);
 }

--- a/src/main/java/com/example/tripy/domain/postfile/PostFileService.java
+++ b/src/main/java/com/example/tripy/domain/postfile/PostFileService.java
@@ -30,4 +30,13 @@ public class PostFileService {
             s3Service.deleteFile(s3Service.parseFileName(postFile.getUrl()));
         }
     }
+
+    //타입별 파일 불러오기
+    public List<String> findImageFileUrlsByPostAndFileType(Post post, FileType fileType) {
+        List<PostFile> postFiles = postFileRepository.findAllByPostAndFileType(post, fileType);
+
+        return postFiles.stream()
+            .map(PostFile::getUrl)
+            .toList();
+    }
 }

--- a/src/main/java/com/example/tripy/domain/posttag/PostTagRepository.java
+++ b/src/main/java/com/example/tripy/domain/posttag/PostTagRepository.java
@@ -1,9 +1,13 @@
 package com.example.tripy.domain.posttag;
 
 import com.example.tripy.domain.post.Post;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostTagRepository extends JpaRepository<PostTag, Long> {
 
     void deleteByPost(Post post);
+
+
+    List<PostTag> findAllByPost(Post post);
 }

--- a/src/main/java/com/example/tripy/domain/posttag/PostTagService.java
+++ b/src/main/java/com/example/tripy/domain/posttag/PostTagService.java
@@ -1,7 +1,5 @@
 package com.example.tripy.domain.posttag;
 
-import static java.util.stream.Collectors.toList;
-
 import com.example.tripy.domain.post.Post;
 import com.example.tripy.domain.tag.Tag;
 import com.example.tripy.domain.tag.TagRepository;

--- a/src/main/java/com/example/tripy/domain/posttag/PostTagService.java
+++ b/src/main/java/com/example/tripy/domain/posttag/PostTagService.java
@@ -1,5 +1,7 @@
 package com.example.tripy.domain.posttag;
 
+import static java.util.stream.Collectors.toList;
+
 import com.example.tripy.domain.post.Post;
 import com.example.tripy.domain.tag.Tag;
 import com.example.tripy.domain.tag.TagRepository;
@@ -28,7 +30,17 @@ public class PostTagService {
         });
     }
 
+    @Transactional
     public void deletePostTagsByPost(Post post) {
         postTagRepository.deleteByPost(post);
+    }
+
+    //게시글 태그 가져오기
+    public List<String> findTagsStringByPost(Post post) {
+        List<PostTag> postTagList = postTagRepository.findAllByPost(post);
+
+        return postTagList.stream()
+            .map(postTag -> postTag.getTag().getTagName())
+            .toList();
     }
 }

--- a/src/main/java/com/example/tripy/domain/tag/Tag.java
+++ b/src/main/java/com/example/tripy/domain/tag/Tag.java
@@ -1,17 +1,13 @@
 package com.example.tripy.domain.tag;
 
-import com.example.tripy.domain.posttag.PostTag;
 import com.example.tripy.global.utils.BaseTimeEntity;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
 import jakarta.validation.constraints.NotNull;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -19,6 +15,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity
+@Builder
 public class Tag extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -27,6 +24,10 @@ public class Tag extends BaseTimeEntity {
     @NotNull
     private String tagName;
 
-    //태그된 횟수
+    static Tag toEntity(String tagName) {
+        return Tag.builder()
+            .tagName(tagName)
+            .build();
+    }
 
 }

--- a/src/main/java/com/example/tripy/domain/tag/TagController.java
+++ b/src/main/java/com/example/tripy/domain/tag/TagController.java
@@ -1,9 +1,20 @@
 package com.example.tripy.domain.tag;
 
+import com.example.tripy.global.common.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RestController
 public class TagController {
+
+    private final TagService tagService;
+
+    @GetMapping("api/tags")
+    public ApiResponse<Long> findTagOrAddTagAndReturnId(
+        @RequestParam String tag) {
+        return ApiResponse.onSuccess(tagService.findTagOrAddTagAndReturnId(tag));
+    }
 }

--- a/src/main/java/com/example/tripy/domain/tag/TagRepository.java
+++ b/src/main/java/com/example/tripy/domain/tag/TagRepository.java
@@ -1,6 +1,10 @@
 package com.example.tripy.domain.tag;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
+
+
+    Optional<Tag> findByTagName(String tagName);
 }

--- a/src/main/java/com/example/tripy/domain/tag/TagService.java
+++ b/src/main/java/com/example/tripy/domain/tag/TagService.java
@@ -1,9 +1,25 @@
 package com.example.tripy.domain.tag;
 
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
 @Service
 public class TagService {
+
+    private final TagRepository tagRepository;
+
+    public Long findTagOrAddTagAndReturnId(String tagName) {
+
+        Optional<Tag> tagOptional = tagRepository.findByTagName(tagName);
+        Tag tag;
+        if(tagOptional.isPresent()) {
+            return tagOptional.get().getId();
+        }
+
+        tag = Tag.toEntity(tagName);
+        tagRepository.save(tag);
+        return tag.getId();
+    }
 }


### PR DESCRIPTION
## 요약

- 게시글 상세 조회
- 게시글 최신순 조회
- 게시글 추천 많은순 조회
- 게시글 인기순TOP 조회

## 상세 내용

- 상세조회는 간단합니당!
- 최신순과 추천 많은순 조회의 경우 `전체 나라 조회`의 경우와 `특정 나라에서의 조회`를 requestParam이 null인지를 통해 구분했습니다
- 인기순 TOP조회의 경우 rank컬럼을 따로 생성했고 더미데이터 삽입으로 진행후에 출시때 이전 사용한 람다식을 가져와 매주 조회수와 추천수 기준으로 업데이트하는 방식으로 진행하겠습니다!

## 이슈 번호

- closed #19
