### PR TITLE
Feat : 여행 일정에 해당하는 개별 가방 생성하기(추가하기)

### DIFF
--- a/src/main/java/com/example/tripy/domain/bag/Bag.java
+++ b/src/main/java/com/example/tripy/domain/bag/Bag.java
@@ -1,5 +1,6 @@
 package com.example.tripy.domain.bag;
 
+import com.example.tripy.domain.bag.dto.BagRequestDto.CreateBagRequest;
 import com.example.tripy.domain.member.Member;
 import com.example.tripy.domain.travelplan.TravelPlan;
 import com.example.tripy.global.utils.BaseTimeEntity;
@@ -20,34 +21,37 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity
+@Builder
 public class Bag extends BaseTimeEntity {
 
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
 
-    @NotNull
-    private String bagName;
+	@NotNull
+	private String bagName;
 
-    @NotNull
-    private String content;
+	private String content;
 
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
-    private Member member;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id")
+	private Member member;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "travelplan_id")
-    private TravelPlan travelPlan;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "travelplan_id")
+	private TravelPlan travelPlan;
 
-    @Builder
-    public Bag(String bagName, String content, Member member, TravelPlan travelPlan) {
-        this.bagName = bagName;
-        this.content = content;
-        this.member = member;
-        this.travelPlan = travelPlan;
-    }
+
+	public static Bag toEntity(CreateBagRequest createBagRequest, Member member,
+		TravelPlan travelPlan) {
+		return Bag.builder()
+			.bagName(createBagRequest.getBagName())
+			.content(null)
+			.member(member)
+			.travelPlan(travelPlan)
+			.build();
+	}
 
 }

--- a/src/main/java/com/example/tripy/domain/bag/BagController.java
+++ b/src/main/java/com/example/tripy/domain/bag/BagController.java
@@ -1,5 +1,6 @@
 package com.example.tripy.domain.bag;
 
+import com.example.tripy.domain.bag.dto.BagRequestDto.CreateBagRequest;
 import com.example.tripy.domain.bag.dto.BagResponseDto.BagListSimpleInfo;
 import com.example.tripy.domain.countrymaterial.CountryMaterialService;
 import com.example.tripy.domain.material.dto.MaterialResponseDto.MaterialListByCountry;
@@ -10,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -47,4 +49,9 @@ public class BagController {
 		return ApiResponse.onSuccess(countryMaterialService.getCountryMaterials(countryName));
 	}
 
+	@PostMapping("/members/bags")
+	public ApiResponse<String> createBag(@RequestBody CreateBagRequest createBagRequest,
+		@RequestParam Long travelPlanId) {
+		return ApiResponse.onSuccess(bagService.addBag(createBagRequest, travelPlanId));
+	}
 }

--- a/src/main/java/com/example/tripy/domain/bag/BagController.java
+++ b/src/main/java/com/example/tripy/domain/bag/BagController.java
@@ -29,18 +29,17 @@ public class BagController {
 	 */
 	@GetMapping("/members/bags/{memberId}")
 	public ApiResponse<PageResponseDto<List<BagListSimpleInfo>>> getBagsList(
-		@PathVariable(value = "memberId") Long memberId, @RequestParam(value = "page") int page,
-		@RequestParam(value = "size") int size) {
-		return ApiResponse.onSuccess(bagService.getTravelBagExistsList(page, size, memberId));
+		@RequestParam(value = "page") int page, @RequestParam(value = "size") int size) {
+		return ApiResponse.onSuccess(bagService.getTravelBagExistsList(page, size));
 	}
 
 	/**
 	 * [POST] 내 여행 일정 목록에서 해당하는 가방 목록 생성하기
 	 */
-	@PostMapping("/members/bags/{memberId}/{travelPlanId}")
-	public ApiResponse<String> updateBagExists(@PathVariable Long memberId,
+	@PostMapping("/members/bags/{travelPlanId}")
+	public ApiResponse<String> updateBagExists(
 		@PathVariable(value = "travelPlanId") Long travelPlanId) {
-		return ApiResponse.onSuccess(bagService.updateBagExists(memberId, travelPlanId));
+		return ApiResponse.onSuccess(bagService.updateBagExists(travelPlanId));
 	}
 
 	@GetMapping("/material-name")

--- a/src/main/java/com/example/tripy/domain/bag/BagService.java
+++ b/src/main/java/com/example/tripy/domain/bag/BagService.java
@@ -1,5 +1,6 @@
 package com.example.tripy.domain.bag;
 
+import com.example.tripy.domain.bag.dto.BagRequestDto.CreateBagRequest;
 import com.example.tripy.domain.bag.dto.BagResponseDto.BagListSimpleInfo;
 import com.example.tripy.domain.cityplan.CityPlanRepository;
 import com.example.tripy.domain.member.Member;
@@ -22,59 +23,77 @@ import org.springframework.stereotype.Service;
 @Service
 public class BagService {
 
-    private final CityPlanRepository cityPlanRepository;
-    private final TravelPlanRepository travelPlanRepository;
-    private final MemberRepository memberRepository;
+	private final CityPlanRepository cityPlanRepository;
+	private final TravelPlanRepository travelPlanRepository;
+	private final MemberRepository memberRepository;
+	private final BagRepository bagRepository;
 
-    // Bag에 대한 간단한 일정 정보 Dto에 매핑
-    public List<BagListSimpleInfo> setBagListSimpleInfo(List<TravelPlan> travelPlans) {
-        return travelPlans.stream()
-            .map(travelPlan -> {
-                List<String> cities = cityPlanRepository.findAllByTravelPlan(travelPlan)
-                    .stream()
-                    .map(cityPlan -> cityPlan.getCity().getName())
-                    .collect(Collectors.toList());
+	// Bag에 대한 간단한 일정 정보 Dto에 매핑
+	public List<BagListSimpleInfo> setBagListSimpleInfo(List<TravelPlan> travelPlans) {
+		return travelPlans.stream()
+			.map(travelPlan -> {
+				List<String> cities = cityPlanRepository.findAllByTravelPlan(travelPlan)
+					.stream()
+					.map(cityPlan -> cityPlan.getCity().getName())
+					.collect(Collectors.toList());
 
-                return new BagListSimpleInfo(
-                    travelPlan.getDeparture(),
-                    travelPlan.getArrival(),
-                    cities,
-                    travelPlan.getId()
-                );
-            })
-            .collect(Collectors.toList());
-    }
+				return new BagListSimpleInfo(
+					travelPlan.getDeparture(),
+					travelPlan.getArrival(),
+					cities,
+					travelPlan.getId()
+				);
+			})
+			.collect(Collectors.toList());
+	}
 
 
-    // 내 일정에 맞는 가방 목록 모두 불러오기
-    public PageResponseDto<List<BagListSimpleInfo>> getTravelBagExistsList(int page, int size,
-        Long memberId) {
+	// 내 일정에 맞는 가방 목록 모두 불러오기
+	public PageResponseDto<List<BagListSimpleInfo>> getTravelBagExistsList(int page, int size,
+		Long memberId) {
 
-        Pageable pageable = PageRequest.of(page, size);
-        Page<TravelPlan> result = travelPlanRepository.findAllByMemberIdAndBagExistsIsTrue(memberId,
-            pageable);
+		Pageable pageable = PageRequest.of(page, size);
+		Page<TravelPlan> result = travelPlanRepository.findAllByMemberIdAndBagExistsIsTrue(memberId,
+			pageable);
 
-        return new PageResponseDto<>(result.getNumber(), result.getTotalPages(),
-            setBagListSimpleInfo(result
-                .stream()
-                .collect(Collectors.toList())));
-    }
+		return new PageResponseDto<>(result.getNumber(), result.getTotalPages(),
+			setBagListSimpleInfo(result
+				.stream()
+				.collect(Collectors.toList())));
+	}
 
-    @Transactional
-    public String updateBagExists(Long memberId, Long travelPlanId) {
+	@Transactional
+	public String updateBagExists(Long memberId, Long travelPlanId) {
 
-        //Member 관련 메서드가 추가되면 수정 예정
-        Member member = memberRepository.findById(memberId)
-            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_MEMBER));
+		//Member 관련 메서드가 추가되면 수정 예정
+		Member member = memberRepository.findById(memberId)
+			.orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_MEMBER));
 
-        //bagExists 값이 False인 TravelPlan만 가능, 이미 가방이 존재하면 예외 처리
-        TravelPlan travelPlan = travelPlanRepository.findByMemberAndIdAndBagExistsIsFalse(member,
-                travelPlanId)
-            .orElseThrow(() -> new GeneralException(ErrorStatus._ALREADY_TRAVEL_PLAN_BAG_EXISTS));
-        // 해당 여행 일정은 가방 목록이 생성되도록 상태 변경
-        travelPlan.updateBagExists();
+		//bagExists 값이 False인 TravelPlan만 가능, 이미 가방이 존재하면 예외 처리
+		TravelPlan travelPlan = travelPlanRepository.findByMemberAndIdAndBagExistsIsFalse(member,
+				travelPlanId)
+			.orElseThrow(() -> new GeneralException(ErrorStatus._ALREADY_TRAVEL_PLAN_BAG_EXISTS));
+		// 해당 여행 일정은 가방 목록이 생성되도록 상태 변경
+		travelPlan.updateBagExists();
 
-        return "내 가방 목록에 추가 완료";
-    }
+		return "내 가방 목록에 추가 완료";
+	}
+
+	@Transactional
+	public String addBag(CreateBagRequest createBagRequest, Long travelPlanId) {
+
+		Member member = memberRepository.findById(1L)
+			.orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_MEMBER));
+
+		//bagExists 값이 True인 TravelPlan만 가능
+		TravelPlan travelPlan = travelPlanRepository.findByMemberAndIdAndBagExistsIsTrue(member,
+				travelPlanId)
+			.orElseThrow(() -> new GeneralException(ErrorStatus._FALSE_TRAVEL_PLAN_BAG_EXISTS));
+
+		Bag bag = Bag.toEntity(createBagRequest, member, travelPlan);
+		bagRepository.save(bag);
+
+		return "가방 추가 완료";
+	}
 
 }

--- a/src/main/java/com/example/tripy/domain/bag/BagService.java
+++ b/src/main/java/com/example/tripy/domain/bag/BagService.java
@@ -87,7 +87,7 @@ public class BagService {
 		//bagExists 값이 True인 TravelPlan만 가능
 		TravelPlan travelPlan = travelPlanRepository.findByMemberAndIdAndBagExistsIsTrue(member,
 				travelPlanId)
-			.orElseThrow(() -> new GeneralException(ErrorStatus._FALSE_TRAVEL_PLAN_BAG_EXISTS));
+			.orElseThrow(() -> new GeneralException(ErrorStatus._FAULT_TRAVEL_PLAN_BAG_EXISTS));
 
 		Bag bag = Bag.toEntity(createBagRequest, member, travelPlan);
 		bagRepository.save(bag);

--- a/src/main/java/com/example/tripy/domain/bag/BagService.java
+++ b/src/main/java/com/example/tripy/domain/bag/BagService.java
@@ -49,11 +49,10 @@ public class BagService {
 
 
 	// 내 일정에 맞는 가방 목록 모두 불러오기
-	public PageResponseDto<List<BagListSimpleInfo>> getTravelBagExistsList(int page, int size,
-		Long memberId) {
+	public PageResponseDto<List<BagListSimpleInfo>> getTravelBagExistsList(int page, int size) {
 
 		Pageable pageable = PageRequest.of(page, size);
-		Page<TravelPlan> result = travelPlanRepository.findAllByMemberIdAndBagExistsIsTrue(memberId,
+		Page<TravelPlan> result = travelPlanRepository.findAllByMemberIdAndBagExistsIsTrue(1L,
 			pageable);
 
 		return new PageResponseDto<>(result.getNumber(), result.getTotalPages(),
@@ -63,10 +62,10 @@ public class BagService {
 	}
 
 	@Transactional
-	public String updateBagExists(Long memberId, Long travelPlanId) {
+	public String updateBagExists(Long travelPlanId) {
 
 		//Member 관련 메서드가 추가되면 수정 예정
-		Member member = memberRepository.findById(memberId)
+		Member member = memberRepository.findById(1L)
 			.orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_MEMBER));
 
 		//bagExists 값이 False인 TravelPlan만 가능, 이미 가방이 존재하면 예외 처리

--- a/src/main/java/com/example/tripy/domain/bag/dto/BagRequestDto.java
+++ b/src/main/java/com/example/tripy/domain/bag/dto/BagRequestDto.java
@@ -1,6 +1,18 @@
 package com.example.tripy.domain.bag.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 public class BagRequestDto {
+
+	@Getter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class CreateBagRequest {
+
+		private String bagName;
+	}
 
 
 }

--- a/src/main/java/com/example/tripy/domain/travelplan/TravelPlanRepository.java
+++ b/src/main/java/com/example/tripy/domain/travelplan/TravelPlanRepository.java
@@ -12,4 +12,7 @@ public interface TravelPlanRepository extends JpaRepository<TravelPlan, Long> {
 
     Page<TravelPlan> findAllByMemberIdAndBagExistsIsTrue(Long memberId, Pageable pageable);
 
+    Optional<TravelPlan> findByMemberAndIdAndBagExistsIsTrue(Member member, Long id);
+
+
 }

--- a/src/main/java/com/example/tripy/global/common/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/tripy/global/common/response/code/status/ErrorStatus.java
@@ -35,7 +35,7 @@ public enum ErrorStatus implements BaseErrorCode {
     _EMPTY_TRAVEL_PLAN(HttpStatus.NOT_FOUND, "TRAVEL_PLAN_001", "존재하지 않는 여행 계획입니다."),
     _ALREADY_TRAVEL_PLAN_BAG_EXISTS(HttpStatus.BAD_REQUEST, "TRAVEL_PLAN_002",
         "이미 가방이 존재하는 여행 계획입니다."),
-    _FALSE_TRAVEL_PLAN_BAG_EXISTS(HttpStatus.BAD_REQUEST,"TRAVEL_PLAN_003",
+    _FAULT_TRAVEL_PLAN_BAG_EXISTS(HttpStatus.BAD_REQUEST,"TRAVEL_PLAN_003",
 		"여행 목록에 해당하는 가방 목록이 생성되지 않았습니다."),
 
     //S3 관련

--- a/src/main/java/com/example/tripy/global/common/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/tripy/global/common/response/code/status/ErrorStatus.java
@@ -35,6 +35,8 @@ public enum ErrorStatus implements BaseErrorCode {
     _EMPTY_TRAVEL_PLAN(HttpStatus.NOT_FOUND, "TRAVEL_PLAN_001", "존재하지 않는 여행 계획입니다."),
     _ALREADY_TRAVEL_PLAN_BAG_EXISTS(HttpStatus.BAD_REQUEST, "TRAVEL_PLAN_002",
         "이미 가방이 존재하는 여행 계획입니다."),
+    _FALSE_TRAVEL_PLAN_BAG_EXISTS(HttpStatus.BAD_REQUEST,"TRAVEL_PLAN_003",
+		"여행 목록에 해당하는 가방 목록이 생성되지 않았습니다."),
 
     //S3 관련
     _FAULT_S3_KEY(HttpStatus.NOT_FOUND, "S3_001", "잘못된 S3 정보입니다."),


### PR DESCRIPTION
## 요약

- 여행 일정에 해당하는 개별 가방을 생성(추가)하는 API를 구현하였습니다.

## 상세 내용

- 코드 통일성을 위해 팀원 `박지운`의 코드를 참고하여 구현하였습니다.
- Bag 엔티티의 `content` 컬럼은 @NotNull 을 제거하여 생성 시에는 가방 이름만 입력하도록 하였습니다.

## 테스트 확인 내용
```json
{
    "isSuccess": true,
    "code": "COMMON200",
    "message": "성공입니다.",
    "result": "가방 추가 완료"
}
```
- 위와 같이 가방이 추가됩니다.

## 질문 및 이외 사항

- 현재 가방 생성 또는 글 생성 시 DB에 createdAt & updatedAt이 반영이 되지 않는데 무슨 문제일까요??

![image](https://github.com/UMC-TRIPY/back-end-spring/assets/125117389/297df0aa-05be-448f-89d4-f74d111adbcb)

![image](https://github.com/UMC-TRIPY/back-end-spring/assets/125117389/28626d14-7e50-4f1e-9140-57a4680a4e28)


## 이슈 번호

- close #40 
