### PR TITLE
hotfix: Swagger 경로 설정

### DIFF
--- a/src/main/java/com/example/tripy/TripyApplication.java
+++ b/src/main/java/com/example/tripy/TripyApplication.java
@@ -1,10 +1,15 @@
 package com.example.tripy;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.servers.Server;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+@OpenAPIDefinition(servers = {
+    @Server(url = "/", description = "Default Server URL")
+})
 @EnableScheduling
 @SpringBootApplication
 @EnableJpaAuditing


### PR DESCRIPTION
## 요약

- Swagger, Cors 에러 핸들링

## 상세 내용
- nginx 설정으로 모든 도메인에서의 cors를 허용해주었는데 swagger에서는 여전히 cors에러가 잡히지 않았습니다.
- 임시방편으로 해당 Server의 URL을 상대경로로 지정해주어 해결했습니다.(아마두, 배포해봐야 확실히 알 것 같음)
<img width="334" alt="스크린샷 2024-03-24 오전 2 49 00" src="https://github.com/UMC-TRIPY/back-end-spring/assets/100510247/b634f99c-3b1e-49b3-bb5e-6c3c397a1183">

- nginx 리버스 프록시 설정으로 http로 들어오는 주소도 https로 리다이렉트 되게 설정해두었습니다.
- SSL 설정도 완료

## 테스트 확인 내용


## 질문 및 이외 사항

## 이슈 번호

