### PR TITLE
Feat: 가방 내부 관련 API 구현

### DIFF
--- a/src/main/java/com/example/tripy/domain/bag/Bag.java
+++ b/src/main/java/com/example/tripy/domain/bag/Bag.java
@@ -54,4 +54,8 @@ public class Bag extends BaseTimeEntity {
 			.build();
 	}
 
+	public void updateBagContent(String content) {
+		this.content = content;
+	}
+
 }

--- a/src/main/java/com/example/tripy/domain/bag/BagController.java
+++ b/src/main/java/com/example/tripy/domain/bag/BagController.java
@@ -6,6 +6,7 @@ import com.example.tripy.domain.bag.dto.BagResponseDto.BagListSimpleInfo;
 import com.example.tripy.domain.bag.dto.BagResponseDto.BagListWithMaterialInfo;
 import com.example.tripy.domain.bag.dto.BagResponseDto.GetBagSimpleInfo;
 import com.example.tripy.domain.countrymaterial.CountryMaterialService;
+import com.example.tripy.domain.material.dto.MaterialRequestDto.CreateMaterialRequest;
 import com.example.tripy.domain.material.dto.MaterialResponseDto.MaterialListByCountry;
 import com.example.tripy.global.common.dto.PageResponseDto;
 import com.example.tripy.global.common.response.ApiResponse;
@@ -100,6 +101,14 @@ public class BagController {
 		@PathVariable(value = "travelPlanId") Long travelPlanId,
 		@PathVariable(value = "bagId") Long bagId) {
 		return ApiResponse.onSuccess(bagService.updateMemo(updateBagContent, travelPlanId, bagId));
+	}
+
+	@PostMapping("/members/bags/{travelPlanId}/{bagId}/materials")
+	public ApiResponse<BagListWithMaterialInfo> addBagMaterial(@RequestBody CreateMaterialRequest createMaterialRequest,
+		@PathVariable(value = "travelPlanId") Long travelPlanId,
+		@PathVariable(value = "bagId") Long bagId) {
+		return ApiResponse.onSuccess(
+			bagService.addBagMaterial(createMaterialRequest, travelPlanId, bagId));
 	}
 
 }

--- a/src/main/java/com/example/tripy/domain/bag/BagController.java
+++ b/src/main/java/com/example/tripy/domain/bag/BagController.java
@@ -1,19 +1,21 @@
 package com.example.tripy.domain.bag;
 
 import com.example.tripy.domain.bag.dto.BagRequestDto.CreateBagRequest;
+import com.example.tripy.domain.bag.dto.BagRequestDto.UpdateBagContent;
 import com.example.tripy.domain.bag.dto.BagResponseDto.BagListSimpleInfo;
 import com.example.tripy.domain.bag.dto.BagResponseDto.BagListWithMaterialInfo;
+import com.example.tripy.domain.bag.dto.BagResponseDto.GetBagSimpleInfo;
 import com.example.tripy.domain.countrymaterial.CountryMaterialService;
 import com.example.tripy.domain.material.dto.MaterialResponseDto.MaterialListByCountry;
 import com.example.tripy.global.common.dto.PageResponseDto;
 import com.example.tripy.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -84,6 +86,20 @@ public class BagController {
 	public ApiResponse<List<BagListWithMaterialInfo>> getBagsListAndMaterialsByTravelPlan(
 		@PathVariable(value = "travelPlanId") Long travelPlanId) {
 		return ApiResponse.onSuccess(bagService.getBagsListAndMaterialsByTravelPlan(travelPlanId));
+	}
+
+
+	/**
+	 * [PATCH] 여행 가방 메모 작성하기
+	 */
+	@Operation(summary = "가방 내부에 메모 작성하기", description = "가방 내부에 메모를 작성합니다.")
+	@Parameter(name = "travelPlanId", description = "여행 계획 Id, Path Variable 입니다.")
+	@Parameter(name = "bagId", description = "가방 Id, Path Variable 입니다.")
+	@PatchMapping("/members/bags/{travelPlanId}/{bagId}")
+	public ApiResponse<GetBagSimpleInfo> updateMemo(@RequestBody UpdateBagContent updateBagContent,
+		@PathVariable(value = "travelPlanId") Long travelPlanId,
+		@PathVariable(value = "bagId") Long bagId) {
+		return ApiResponse.onSuccess(bagService.updateMemo(updateBagContent, travelPlanId, bagId));
 	}
 
 }

--- a/src/main/java/com/example/tripy/domain/bag/BagController.java
+++ b/src/main/java/com/example/tripy/domain/bag/BagController.java
@@ -151,4 +151,17 @@ public class BagController {
 		return ApiResponse.onSuccess(
 			bagService.deleteBagMaterial(travelPlanId, bagId, materialId));
 	}
+
+	/**
+	 * [PATCH] 여행 가방 준비물 체크박스 수정
+	 */
+	@Operation(summary = "여행 가방 준비물 체크박스 업데이트", description = "가방의 준비물 체크 상태를 수정합니다.")
+	@Parameter(name = "travelPlanId", description = "여행 계획 Id, Path Variable 입니다.")
+	@Parameter(name = "bagId", description = "가방 Id, Path Variable 입니다.")
+	@Parameter(name = "materialId", description = "준비물 Id, query string 입니다.")
+	@PatchMapping("/members/bags/{travelPlanId}/{bagId}/materials/check")
+	public ApiResponse<Boolean> updateBagMaterialIsChecked(@PathVariable(value = "travelPlanId") Long travelPlanId,
+		@PathVariable(value = "bagId") Long bagId, @RequestParam Long materialId){
+		return ApiResponse.onSuccess(bagService.updateBagMaterialIsChecked(travelPlanId, bagId, materialId));
+	}
 }

--- a/src/main/java/com/example/tripy/domain/bag/BagController.java
+++ b/src/main/java/com/example/tripy/domain/bag/BagController.java
@@ -117,4 +117,19 @@ public class BagController {
 			bagService.addBagMaterial(createMaterialRequest, travelPlanId, bagId));
 	}
 
+
+	/**
+	 * [PATCH] 여행 가방 준비물 이름 수정
+	 */
+	@Operation(summary = "여행 가방 준비물 이름 수정하기", description = "가방의 준비물 이름을 수정합니다.")
+	@Parameter(name = "travelPlanId", description = "여행 계획 Id, Path Variable 입니다.")
+	@Parameter(name = "bagId", description = "가방 Id, Path Variable 입니다.")
+	@Parameter(name = "materialId", description = "준비물 Id, query string 입니다.")
+	@PatchMapping("/members/bags/{travelPlanId}/{bagId}/materials")
+	public ApiResponse<BagListWithMaterialInfo> updateBagMaterialName(@RequestBody CreateMaterialRequest updateMaterialRequest,
+		@PathVariable(value = "travelPlanId") Long travelPlanId,
+		@PathVariable(value = "bagId") Long bagId, @RequestParam Long materialId) {
+		return ApiResponse.onSuccess(
+			bagService.updateBagMaterialName(updateMaterialRequest, travelPlanId, bagId, materialId));
+	}
 }

--- a/src/main/java/com/example/tripy/domain/bag/BagController.java
+++ b/src/main/java/com/example/tripy/domain/bag/BagController.java
@@ -103,6 +103,12 @@ public class BagController {
 		return ApiResponse.onSuccess(bagService.updateMemo(updateBagContent, travelPlanId, bagId));
 	}
 
+	/**
+	 * [POST] 여행 가방에 준비물 추가하기
+	 */
+	@Operation(summary = "가방 내부에 준비물 추가하기", description = "가방 내부에 준비물을 추가합니다.")
+	@Parameter(name = "travelPlanId", description = "여행 계획 Id, Path Variable 입니다.")
+	@Parameter(name = "bagId", description = "가방 Id, Path Variable 입니다.")
 	@PostMapping("/members/bags/{travelPlanId}/{bagId}/materials")
 	public ApiResponse<BagListWithMaterialInfo> addBagMaterial(@RequestBody CreateMaterialRequest createMaterialRequest,
 		@PathVariable(value = "travelPlanId") Long travelPlanId,

--- a/src/main/java/com/example/tripy/domain/bag/BagController.java
+++ b/src/main/java/com/example/tripy/domain/bag/BagController.java
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -110,7 +111,8 @@ public class BagController {
 	@Parameter(name = "travelPlanId", description = "여행 계획 Id, Path Variable 입니다.")
 	@Parameter(name = "bagId", description = "가방 Id, Path Variable 입니다.")
 	@PostMapping("/members/bags/{travelPlanId}/{bagId}/materials")
-	public ApiResponse<BagListWithMaterialInfo> addBagMaterial(@RequestBody CreateMaterialRequest createMaterialRequest,
+	public ApiResponse<BagListWithMaterialInfo> addBagMaterial(
+		@RequestBody CreateMaterialRequest createMaterialRequest,
 		@PathVariable(value = "travelPlanId") Long travelPlanId,
 		@PathVariable(value = "bagId") Long bagId) {
 		return ApiResponse.onSuccess(
@@ -126,10 +128,27 @@ public class BagController {
 	@Parameter(name = "bagId", description = "가방 Id, Path Variable 입니다.")
 	@Parameter(name = "materialId", description = "준비물 Id, query string 입니다.")
 	@PatchMapping("/members/bags/{travelPlanId}/{bagId}/materials")
-	public ApiResponse<BagListWithMaterialInfo> updateBagMaterialName(@RequestBody CreateMaterialRequest updateMaterialRequest,
+	public ApiResponse<BagListWithMaterialInfo> updateBagMaterialName(
+		@RequestBody CreateMaterialRequest updateMaterialRequest,
 		@PathVariable(value = "travelPlanId") Long travelPlanId,
 		@PathVariable(value = "bagId") Long bagId, @RequestParam Long materialId) {
 		return ApiResponse.onSuccess(
-			bagService.updateBagMaterialName(updateMaterialRequest, travelPlanId, bagId, materialId));
+			bagService.updateBagMaterialName(updateMaterialRequest, travelPlanId, bagId,
+				materialId));
+	}
+
+	/**
+	 * [DELETE] 여행 가방 준비물 삭제
+	 */
+	@Operation(summary = "여행 가방 준비물 삭제하기", description = "가방의 준비물을 삭제합니다.")
+	@Parameter(name = "travelPlanId", description = "여행 계획 Id, Path Variable 입니다.")
+	@Parameter(name = "bagId", description = "가방 Id, Path Variable 입니다.")
+	@Parameter(name = "materialId", description = "준비물 Id, query string 입니다.")
+	@DeleteMapping("/members/bags/{travelPlanId}/{bagId}/materials")
+	public ApiResponse<BagListWithMaterialInfo> deleteBagMaterial(
+		@PathVariable(value = "travelPlanId") Long travelPlanId,
+		@PathVariable(value = "bagId") Long bagId, @RequestParam Long materialId) {
+		return ApiResponse.onSuccess(
+			bagService.deleteBagMaterial(travelPlanId, bagId, materialId));
 	}
 }

--- a/src/main/java/com/example/tripy/domain/bag/BagRepository.java
+++ b/src/main/java/com/example/tripy/domain/bag/BagRepository.java
@@ -2,6 +2,7 @@ package com.example.tripy.domain.bag;
 
 import com.example.tripy.domain.travelplan.TravelPlan;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,5 +12,7 @@ public interface BagRepository extends JpaRepository<Bag, Long> {
 	Page<Bag> findAllByMemberId(Long memberId, Pageable pageable);
 
 	List<Bag> findBagsByTravelPlan(TravelPlan travelPlan);
+
+	Optional<Bag> findBagByIdAndTravelPlanId(Long id, Long travelPlanId);
 
 }

--- a/src/main/java/com/example/tripy/domain/bag/BagService.java
+++ b/src/main/java/com/example/tripy/domain/bag/BagService.java
@@ -3,8 +3,10 @@ package com.example.tripy.domain.bag;
 import static com.example.tripy.domain.bag.dto.BagResponseDto.toBagListWithMaterialInfoDto;
 
 import com.example.tripy.domain.bag.dto.BagRequestDto.CreateBagRequest;
+import com.example.tripy.domain.bag.dto.BagRequestDto.UpdateBagContent;
 import com.example.tripy.domain.bag.dto.BagResponseDto.BagListSimpleInfo;
 import com.example.tripy.domain.bag.dto.BagResponseDto.BagListWithMaterialInfo;
+import com.example.tripy.domain.bag.dto.BagResponseDto.GetBagSimpleInfo;
 import com.example.tripy.domain.bagmaterials.BagMaterialsRepository;
 import com.example.tripy.domain.bagmaterials.dto.BagMaterialsResponseDto.BagMaterialInfo;
 import com.example.tripy.domain.cityplan.CityPlanRepository;
@@ -131,6 +133,18 @@ public class BagService {
 					bag.getTravelPlan().getId());
 			})
 			.collect(Collectors.toList());
+	}
+
+	@Transactional
+	public GetBagSimpleInfo updateMemo(UpdateBagContent updateBagContent, Long travelPlanId,
+		Long bagId) {
+
+		Bag bag = bagRepository.findBagByIdAndTravelPlanId(bagId, travelPlanId)
+			.orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_BAG));
+
+		bag.updateBagContent(updateBagContent.getBagContent());
+
+		return GetBagSimpleInfo.toDto(bag);
 	}
 
 }

--- a/src/main/java/com/example/tripy/domain/bag/BagService.java
+++ b/src/main/java/com/example/tripy/domain/bag/BagService.java
@@ -217,5 +217,14 @@ public class BagService {
 			materialId);
 	}
 
+	@Transactional
+	public Boolean updateBagMaterialIsChecked(Long travelPlanId, Long bagId,
+		Long materialId){
+		Bag bag = getBag(bagId, travelPlanId);
+		BagMaterials bagMaterial = getBagMaterials(bag, materialId);
+
+		return bagMaterial.updateBagMaterialIsChecked();
+
+	}
 
 }

--- a/src/main/java/com/example/tripy/domain/bag/BagService.java
+++ b/src/main/java/com/example/tripy/domain/bag/BagService.java
@@ -135,8 +135,7 @@ public class BagService {
 	public GetBagSimpleInfo updateMemo(UpdateBagContent updateBagContent, Long travelPlanId,
 		Long bagId) {
 
-		Bag bag = bagRepository.findBagByIdAndTravelPlanId(bagId, travelPlanId)
-			.orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_BAG));
+		Bag bag = getBag(bagId, travelPlanId);
 
 		bag.updateBagContent(updateBagContent.getBagContent());
 
@@ -148,8 +147,7 @@ public class BagService {
 		Long travelPlanId,
 		Long bagId) {
 
-		Bag bag = bagRepository.findBagByIdAndTravelPlanId(bagId, travelPlanId)
-			.orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_BAG));
+		Bag bag = getBag(bagId, travelPlanId);
 
 		saveMaterialAndLinkToBag(bag, createMaterialRequest);
 
@@ -175,11 +173,32 @@ public class BagService {
 	private BagListWithMaterialInfo getBagMaterials(Bag bag) {
 		List<BagMaterialInfo> bagMaterialInfos = bagMaterialsRepository.findBagMaterialsByBag(
 				bag).stream()
-			.map(bagMaterials -> new BagMaterialInfo(bagMaterials.getMaterial().getName(),
+			.map(bagMaterials -> new BagMaterialInfo(bagMaterials.getId(),
+				bagMaterials.getMaterial().getName(),
 				bagMaterials.getIsChecked()))
 			.collect(Collectors.toList());
 
 		return toBagListWithMaterialInfoDto(bag, bagMaterialInfos);
+	}
+
+	@Transactional
+	public BagListWithMaterialInfo updateBagMaterialName(
+		CreateMaterialRequest createMaterialRequest, Long travelPlanId, Long bagId,
+		Long materialId) {
+
+		Bag bag = getBag(bagId, travelPlanId);
+
+		BagMaterials bagMaterial = bagMaterialsRepository.findBagMaterialsByBagAndMaterialId(bag,
+			materialId);
+
+		bagMaterial.updateMaterialName(createMaterialRequest.getMaterialName());
+
+		return getBagMaterials(bag);
+	}
+
+	private Bag getBag(Long bagId, Long travelPlanId) {
+		return bagRepository.findBagByIdAndTravelPlanId(bagId, travelPlanId)
+			.orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_BAG));
 	}
 
 

--- a/src/main/java/com/example/tripy/domain/bag/BagService.java
+++ b/src/main/java/com/example/tripy/domain/bag/BagService.java
@@ -188,8 +188,7 @@ public class BagService {
 
 		Bag bag = getBag(bagId, travelPlanId);
 
-		BagMaterials bagMaterial = bagMaterialsRepository.findBagMaterialsByBagAndMaterialId(bag,
-			materialId);
+		BagMaterials bagMaterial = getBagMaterials(bag, materialId);
 
 		bagMaterial.updateMaterialName(createMaterialRequest.getMaterialName());
 
@@ -199,6 +198,23 @@ public class BagService {
 	private Bag getBag(Long bagId, Long travelPlanId) {
 		return bagRepository.findBagByIdAndTravelPlanId(bagId, travelPlanId)
 			.orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_BAG));
+	}
+
+	@Transactional
+	public BagListWithMaterialInfo deleteBagMaterial(Long travelPlanId, Long bagId,
+		Long materialId) {
+
+		Bag bag = getBag(bagId, travelPlanId);
+		BagMaterials bagMaterial = getBagMaterials(bag, materialId);
+
+		bagMaterialsRepository.delete(bagMaterial);
+
+		return getBagMaterials(bag);
+	}
+
+	private BagMaterials getBagMaterials(Bag bag, Long materialId) {
+		return bagMaterialsRepository.findBagMaterialsByBagAndMaterialId(bag,
+			materialId);
 	}
 
 

--- a/src/main/java/com/example/tripy/domain/bag/dto/BagRequestDto.java
+++ b/src/main/java/com/example/tripy/domain/bag/dto/BagRequestDto.java
@@ -14,5 +14,13 @@ public class BagRequestDto {
 		private String bagName;
 	}
 
+	@Getter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class UpdateBagContent {
+
+		private String bagContent;
+	}
+
 
 }

--- a/src/main/java/com/example/tripy/domain/bag/dto/BagResponseDto.java
+++ b/src/main/java/com/example/tripy/domain/bag/dto/BagResponseDto.java
@@ -1,5 +1,6 @@
 package com.example.tripy.domain.bag.dto;
 
+import com.example.tripy.domain.bag.Bag;
 import com.example.tripy.domain.bagmaterials.dto.BagMaterialsResponseDto.BagMaterialInfo;
 import com.example.tripy.domain.travelplan.TravelPlan;
 import java.util.Date;
@@ -50,6 +51,28 @@ public class BagResponseDto {
 			.bagMaterials(bagMaterials)
 			.travelPlanId(travelPlanId)
 			.build();
+	}
+
+	@Getter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	@Builder
+	public static class GetBagSimpleInfo {
+
+		private String bagName;
+		private Long travelPlanId;
+		private Long bagId;
+		private String bagContent;
+
+
+		public static GetBagSimpleInfo toDto(Bag bag) {
+			return GetBagSimpleInfo.builder()
+				.bagName(bag.getBagName())
+				.bagId(bag.getId())
+				.travelPlanId(bag.getTravelPlan().getId())
+				.bagContent(bag.getContent())
+				.build();
+		}
 	}
 
 }

--- a/src/main/java/com/example/tripy/domain/bag/dto/BagResponseDto.java
+++ b/src/main/java/com/example/tripy/domain/bag/dto/BagResponseDto.java
@@ -38,18 +38,20 @@ public class BagResponseDto {
 	@Builder
 	public static class BagListWithMaterialInfo {
 
+		private Long bagId;
 		private String bagName;
-		private List<BagMaterialInfo> bagMaterials;
 		private Long travelPlanId;
+		private List<BagMaterialInfo> bagMaterials;
 
 	}
 
-	public static BagListWithMaterialInfo toBagListWithMaterialInfoDto(String bagName,
-		List<BagMaterialInfo> bagMaterials, Long travelPlanId) {
+	public static BagListWithMaterialInfo toBagListWithMaterialInfoDto(Bag bag,
+		List<BagMaterialInfo> bagMaterials) {
 		return BagListWithMaterialInfo.builder()
-			.bagName(bagName)
+			.bagId(bag.getId())
+			.bagName(bag.getBagName())
+			.travelPlanId(bag.getTravelPlan().getId())
 			.bagMaterials(bagMaterials)
-			.travelPlanId(travelPlanId)
 			.build();
 	}
 

--- a/src/main/java/com/example/tripy/domain/bagmaterials/BagMaterials.java
+++ b/src/main/java/com/example/tripy/domain/bagmaterials/BagMaterials.java
@@ -45,4 +45,9 @@ public class BagMaterials extends BaseTimeEntity {
         this.material.updateMaterial(updateName);
     }
 
+    public Boolean updateBagMaterialIsChecked(){
+        this.isChecked = !this.isChecked;
+        return this.isChecked;
+    }
+
 }

--- a/src/main/java/com/example/tripy/domain/bagmaterials/BagMaterials.java
+++ b/src/main/java/com/example/tripy/domain/bagmaterials/BagMaterials.java
@@ -41,4 +41,8 @@ public class BagMaterials extends BaseTimeEntity {
             .build();
     }
 
+    public void updateMaterialName(String updateName) {
+        this.material.updateMaterial(updateName);
+    }
+
 }

--- a/src/main/java/com/example/tripy/domain/bagmaterials/BagMaterials.java
+++ b/src/main/java/com/example/tripy/domain/bagmaterials/BagMaterials.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -17,6 +18,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity
+@Builder
 public class BagMaterials extends BaseTimeEntity {
 
     @Id
@@ -30,4 +32,13 @@ public class BagMaterials extends BaseTimeEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Material material;
+
+    public static BagMaterials toEntity(Bag bag, Material material){
+        return BagMaterials.builder()
+            .bag(bag)
+            .material(material)
+            .isChecked(false)
+            .build();
+    }
+
 }

--- a/src/main/java/com/example/tripy/domain/bagmaterials/BagMaterialsRepository.java
+++ b/src/main/java/com/example/tripy/domain/bagmaterials/BagMaterialsRepository.java
@@ -8,4 +8,6 @@ public interface BagMaterialsRepository extends JpaRepository<BagMaterials, Long
 
 	List<BagMaterials> findBagMaterialsByBag(Bag bag);
 
+	BagMaterials findBagMaterialsByBagAndMaterialId(Bag bag, Long materialId);
+
 }

--- a/src/main/java/com/example/tripy/domain/bagmaterials/dto/BagMaterialsResponseDto.java
+++ b/src/main/java/com/example/tripy/domain/bagmaterials/dto/BagMaterialsResponseDto.java
@@ -11,6 +11,7 @@ public class BagMaterialsResponseDto {
 	@AllArgsConstructor
 	public static class BagMaterialInfo {
 
+		private Long materialId;
 		private String materialName;
 		private Boolean isChecked;
 

--- a/src/main/java/com/example/tripy/domain/material/Material.java
+++ b/src/main/java/com/example/tripy/domain/material/Material.java
@@ -38,4 +38,8 @@ public class Material extends BaseTimeEntity {
             .name(createMaterialRequest.getMaterialName())
             .build();
     }
+
+    public void updateMaterial(String name) {
+        this.name = name;
+    }
 }

--- a/src/main/java/com/example/tripy/domain/material/Material.java
+++ b/src/main/java/com/example/tripy/domain/material/Material.java
@@ -2,6 +2,7 @@ package com.example.tripy.domain.material;
 
 import com.example.tripy.domain.bagmaterials.BagMaterials;
 import com.example.tripy.domain.countrymaterial.CountryMaterial;
+import com.example.tripy.domain.material.dto.MaterialRequestDto.CreateMaterialRequest;
 import com.example.tripy.global.utils.BaseTimeEntity;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
@@ -13,6 +14,7 @@ import jakarta.persistence.OneToMany;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -20,6 +22,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity
+@Builder
 public class Material extends BaseTimeEntity {
 
 
@@ -30,5 +33,9 @@ public class Material extends BaseTimeEntity {
     private String name;
 
 
-
+    public static Material toEntity(CreateMaterialRequest createMaterialRequest) {
+        return Material.builder()
+            .name(createMaterialRequest.getMaterialName())
+            .build();
+    }
 }

--- a/src/main/java/com/example/tripy/domain/material/dto/MaterialRequestDto.java
+++ b/src/main/java/com/example/tripy/domain/material/dto/MaterialRequestDto.java
@@ -1,0 +1,17 @@
+package com.example.tripy.domain.material.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class MaterialRequestDto {
+
+	@Getter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class CreateMaterialRequest {
+
+		private String materialName;
+	}
+
+}

--- a/src/main/java/com/example/tripy/global/common/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/tripy/global/common/response/code/status/ErrorStatus.java
@@ -48,7 +48,10 @@ public enum ErrorStatus implements BaseErrorCode {
     _EMPTY_TAG(HttpStatus.CONFLICT, "TAG_001", "태그가 존재하지 않습니다."),
 
     //게시글 관련
-    _EMPTY_POST(HttpStatus.CONFLICT, "POST_001", "게시글이 존재하지 않습니다.");
+    _EMPTY_POST(HttpStatus.CONFLICT, "POST_001", "게시글이 존재하지 않습니다."),
+
+    //가방 관련
+    _EMPTY_BAG(HttpStatus.NOT_FOUND,"BAG_001","존재하지 않는 가방입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
## 요약

- 가방 내부 관련 API를 모두 구현하였습니다.
- 목록은 아래와 같습니다.
- 가방 내부에 메모 작성
- 가방 내부에 준비물 추가
- 가방 준비물 이름 수정
- 가방 준비물 삭제
- 가방 준비물 체크박스 업데이트

## 상세 내용

- 간단한 API들 이라서 어려운 내용은 없지만, 내부 함수를 좀 더 깔끔하게 수정해보았습니다. 구현하면서 프론트에 전달되면 좋을 것 같은 필드들을 추가하였습니다.
- 가방에 존재하는 준비물 삭제 API는 일단 Hard Delete로 구현하였습니다. Soft Delete로 구현해야한다면 수정하도록 하겠습니다.

## 테스트 확인 내용
- 

## 질문 및 이외 사항

- 다음으로는 여행 계획 관련한 API들을 얼른 마무리하도록 하겠습니다!

## 이슈 번호

- close #41 
