### PR TITLE
Feat: 화폐 & 날씨 API 구현

### DIFF
--- a/src/main/java/com/example/tripy/domain/country/Country.java
+++ b/src/main/java/com/example/tripy/domain/country/Country.java
@@ -31,7 +31,7 @@ public class Country {
     private String name;
 
 
-    @OneToOne
+    @ManyToOne
     @JoinColumn(name = "currency_id")
     private Currency currency;
 

--- a/src/main/java/com/example/tripy/domain/currency/Currency.java
+++ b/src/main/java/com/example/tripy/domain/currency/Currency.java
@@ -31,9 +31,5 @@ public class Currency extends BaseTimeEntity {
 
     private float deal;
 
-    private String countryName;
-
-    @OneToOne(mappedBy = "currency")
-    private Country country;
 
 }

--- a/src/main/java/com/example/tripy/domain/currency/CurrencyRepository.java
+++ b/src/main/java/com/example/tripy/domain/currency/CurrencyRepository.java
@@ -4,5 +4,4 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CurrencyRepository extends JpaRepository<Currency, Long> {
-    Optional<Currency> findByCountryName(String countryName);
 }

--- a/src/main/java/com/example/tripy/domain/currency/CurrencyService.java
+++ b/src/main/java/com/example/tripy/domain/currency/CurrencyService.java
@@ -5,7 +5,6 @@ import com.example.tripy.domain.country.CountryRepository;
 import com.example.tripy.domain.currency.dto.CurrencyResponseDto;
 import com.example.tripy.global.common.response.code.status.ErrorStatus;
 import com.example.tripy.global.common.response.exception.GeneralException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -31,15 +30,12 @@ public class CurrencyService {
         Country country = countryRepository.findById(countryId)
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_COUNTRY));
 
+        Currency currency = country.getCurrency();
         String countryName = country.getName();
 
         if(countryName.equals("스페인") || countryName.equals("프랑스")){
             countryName = "유로";
         }
-
-        Currency currency = currencyRepository.findByCountryName(countryName)
-            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_CURRENCY));
-
         return CurrencyResponseDto.euroToDto(currency, countryName);
     }
 }

--- a/src/main/java/com/example/tripy/domain/currency/dto/CurrencyResponseDto.java
+++ b/src/main/java/com/example/tripy/domain/currency/dto/CurrencyResponseDto.java
@@ -27,7 +27,6 @@ public class CurrencyResponseDto {
             .deal(entity.getDeal())
             .currencyUnit(entity.getCurrencyUnit())
             .currencyName(entity.getCurrencyName())
-            .countryName(entity.getCountryName())
             .build();
     }
 

--- a/src/main/java/com/example/tripy/domain/wheather/WeatherController.java
+++ b/src/main/java/com/example/tripy/domain/wheather/WeatherController.java
@@ -1,7 +1,6 @@
 package com.example.tripy.domain.wheather;
 
-import com.example.tripy.domain.wheather.dto.WheatherResponseDto.WhetherResponseSimpleInfo;
-import java.util.List;
+import com.example.tripy.domain.wheather.dto.WheatherResponseDto.WhetherResponseInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,7 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class WeatherController {
     private final WeatherService weatherService;
     @GetMapping("/{cityId}")
-    public ResponseEntity<List<WhetherResponseSimpleInfo>> getWeatherList(@PathVariable Long cityId){
+    public ResponseEntity<WhetherResponseInfo> getWeatherList(@PathVariable Long cityId){
         return ResponseEntity.ok(weatherService.getWeatherList(cityId));
     }
 }

--- a/src/main/java/com/example/tripy/domain/wheather/WeatherRepository.java
+++ b/src/main/java/com/example/tripy/domain/wheather/WeatherRepository.java
@@ -1,6 +1,9 @@
 package com.example.tripy.domain.wheather;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
+import java.util.Objects;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -20,4 +23,13 @@ public interface WeatherRepository extends JpaRepository<Weather, Long> {
         )
     List<Object[]> findAllByCityNameAndByDateTime(String cityName);
 
+
+    @Query("SELECT w.temp " +
+        "FROM Weather w " +
+        "WHERE w.cityName = :cityName " +
+        "AND w.weatherDate = :currentDate " +
+        "AND w.weatherTime <= :currentTime " +
+        "ORDER BY w.weatherDate DESC " +
+        "LIMIT 1")
+    double findClosestTemperature(String cityName, LocalDate currentDate, LocalTime currentTime);
 }

--- a/src/main/java/com/example/tripy/domain/wheather/WeatherService.java
+++ b/src/main/java/com/example/tripy/domain/wheather/WeatherService.java
@@ -2,11 +2,19 @@ package com.example.tripy.domain.wheather;
 
 import com.example.tripy.domain.city.City;
 import com.example.tripy.domain.city.CityRepository;
+import com.example.tripy.domain.wheather.dto.WheatherResponseDto.WhetherResponseInfo;
 import com.example.tripy.domain.wheather.dto.WheatherResponseDto.WhetherResponseSimpleInfo;
 import com.example.tripy.global.common.response.code.status.ErrorStatus;
 import com.example.tripy.global.common.response.exception.GeneralException;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
+import javax.swing.plaf.IconUIResource;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -17,18 +25,25 @@ public class WeatherService {
     private final WeatherRepository weatherRepository;
     private final CityRepository cityRepository;
 
-    public List<WhetherResponseSimpleInfo> getWeatherList(Long cityId) {
+    public WhetherResponseInfo getWeatherList(Long cityId) {
 
         City city = cityRepository.findById(cityId).orElseThrow(() -> new GeneralException(
             ErrorStatus._EMPTY_CITY));
 
         List<Object[]> weatherList = weatherRepository.findAllByCityNameAndByDateTime(city.getName());
 
-        List<WhetherResponseSimpleInfo> result
+        List<WhetherResponseSimpleInfo> whetherResponseSimpleInfoList
             = weatherList.stream()
             .map(WhetherResponseSimpleInfo::toDto)
+            .sorted(Comparator.comparing(WhetherResponseSimpleInfo::getWeatherDate)) // datetime 기준으로 오름차순 정렬
             .collect(Collectors.toList());
 
-        return result;
+        LocalDate nowDate = LocalDate.now();
+        LocalTime nowTime = LocalTime.now();
+
+        double temp = weatherRepository.findClosestTemperature(
+            city.getName(), nowDate, nowTime);
+
+        return WhetherResponseInfo.toDto(temp, whetherResponseSimpleInfoList);
     }
 }

--- a/src/main/java/com/example/tripy/domain/wheather/dto/WheatherResponseDto.java
+++ b/src/main/java/com/example/tripy/domain/wheather/dto/WheatherResponseDto.java
@@ -1,5 +1,6 @@
 package com.example.tripy.domain.wheather.dto;
 
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -27,11 +28,25 @@ public class WheatherResponseDto {
             return WhetherResponseSimpleInfo.builder()
                 .cityName(object[0].toString())
                 .tempMax(Double.valueOf(object[1].toString()))
-                .tempMin(Double.valueOf(object[1].toString()))
+                .tempMin(Double.valueOf(object[2].toString()))
                 .weatherDate(object[3].toString())
                 .build();
         }
     }
 
-
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class WhetherResponseInfo {
+        Number currentTemp;
+//        String weatherMain;
+        List<WhetherResponseSimpleInfo> whetherResponseSimpleInfoList;
+        public static WhetherResponseInfo toDto(Double temp, List<WhetherResponseSimpleInfo> whetherResponseSimpleInfoList) {
+            return WhetherResponseInfo.builder()
+                .currentTemp(temp)
+                .whetherResponseSimpleInfoList(whetherResponseSimpleInfoList)
+                .build();
+        }
+    }
 }


### PR DESCRIPTION
## 요약
- 환율, 날씨 API 리팩토링

## 상세 내용
**환율, 날씨 업데이트**
- 업데이트 로직은 모두 AWS 람다함수로 작성하였습니다.

**특이사항**
- 날씨를 조회할 때 오늘의 경우 어떤 날씨인지(Cloud, sunny 들)를 보내줘야 합니다.
- db에는 저장되어 있는데 현재 객체 변환 에러로 현재는 넣지 않았습니다.
- 빠르게 작업해야 하니 일단 올리고 다음 PR에 적용하겠습니다.

**중요사항**
- 기존 나라와 환율이 OneToOne으로 매핑되어있었으나 사실 여러 나라가 하나의 화폐를 사용하는 경우가 있습니다(유럽)
- 이에 따라 db구조가 바뀌었고 또 바뀐 db를 업데이트 시켜주면서 db의 값도 새로 넣어주시길 부탁드립니다.
- 제가 맡고 있는 번역, 환율, 날씨 데이터는 스케줄러에 의해 작동하지만 API Gateway로 업데이트 시킬 수 있으니 한번씩만 호출해주시면 됩니다.
- (번역 데이터는 Cron 식을 수정해 한번만 실행해주시면 될 것 같습니다)

## 테스트 확인 내용
<img width="823" alt="스크린샷 2024-05-15 오후 1 37 21" src="https://github.com/UMC-TRIPY/back-end-spring/assets/100510247/288bc37d-8283-4ffc-9a4f-9ce80fc9a307">

- 다음 pr에는 currentWheatherMain도 넣어줄 것입니다!

## 질문 및 이외 사항

## 이슈 번호

