### PR TITLE
Fix: BagMaterialInfo 오류 수정

### DIFF
--- a/src/main/java/com/example/tripy/domain/bag/BagService.java
+++ b/src/main/java/com/example/tripy/domain/bag/BagService.java
@@ -166,7 +166,7 @@ public class BagService {
 	private BagListWithMaterialInfo getBagMaterials(Bag bag) {
 		List<BagMaterialInfo> bagMaterialInfos = bagMaterialsRepository.findBagMaterialsByBag(
 				bag).stream()
-			.map(bagMaterials -> new BagMaterialInfo(bagMaterials.getId(),
+			.map(bagMaterials -> new BagMaterialInfo(bagMaterials.getMaterial().getId(),
 				bagMaterials.getMaterial().getName(),
 				bagMaterials.getIsChecked()))
 			.collect(Collectors.toList());


### PR DESCRIPTION
## 요약

- BagMaterialInfo 오류를 수정

## 상세 내용

- 가방 내부에 준비물 추가하기로 추가한 데이터들이 삭제, 이름 수정, 체크 수정 되도록 수정하였습니다.
- 기존에는 연관관계 ID를 불러오는 로직이라 오류가 있어 수정,삭제 되면 반영될 수 있도록 수정하였습니다.

## 테스트 확인 내용


## 질문 및 이외 사항


## 이슈 번호

- close #71 
